### PR TITLE
fix(web): update BlueprintLink to use assets/ path structure

### DIFF
--- a/web/src/components/BlueprintLink.tsx
+++ b/web/src/components/BlueprintLink.tsx
@@ -3,14 +3,12 @@ import { BlueprintModal } from './BlueprintModal';
 
 interface BlueprintLinkProps {
   factionId: string;
-  unitId: string;
   resourceName: string;
   displayName?: string;
 }
 
 export const BlueprintLink: React.FC<BlueprintLinkProps> = ({
   factionId,
-  unitId,
   resourceName,
   displayName
 }) => {
@@ -18,10 +16,9 @@ export const BlueprintLink: React.FC<BlueprintLinkProps> = ({
 
   // Convert PA resource name to faction data path
   // e.g., /pa/units/land/tank_light_laser/tank_light_laser.json
-  // becomes /factions/MLA/units/tank_light_laser/tank_light_laser.json
+  // becomes /factions/MLA/assets/pa/units/land/tank_light_laser/tank_light_laser.json
   const getBlueprintPath = () => {
-    const filename = resourceName.split('/').pop();
-    return `/factions/${factionId}/units/${unitId}/${filename}`;
+    return `/factions/${factionId}/assets${resourceName}`;
   };
 
   return (

--- a/web/src/components/__tests__/BlueprintLink.test.tsx
+++ b/web/src/components/__tests__/BlueprintLink.test.tsx
@@ -21,7 +21,6 @@ describe('BlueprintLink', () => {
     render(
       <BlueprintLink
         factionId="MLA"
-        unitId="tank"
         resourceName="/pa/units/land/tank/tank.json"
         displayName="Tank Blueprint"
       />
@@ -35,7 +34,6 @@ describe('BlueprintLink', () => {
     render(
       <BlueprintLink
         factionId="MLA"
-        unitId="tank"
         resourceName="/pa/units/land/tank/tank.json"
       />
     )
@@ -48,7 +46,6 @@ describe('BlueprintLink', () => {
     render(
       <BlueprintLink
         factionId="MLA"
-        unitId="tank"
         resourceName="/pa/units/land/tank/tank.json"
         displayName="View Blueprint"
       />
@@ -68,7 +65,6 @@ describe('BlueprintLink', () => {
     render(
       <BlueprintLink
         factionId="MLA"
-        unitId="tank"
         resourceName="/pa/units/land/tank/tank.json"
         displayName="View"
       />
@@ -79,7 +75,7 @@ describe('BlueprintLink', () => {
     // Check that fetch was called with correct path (includes abort signal)
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
-        '/factions/MLA/units/tank/tank.json',
+        '/factions/MLA/assets/pa/units/land/tank/tank.json',
         expect.objectContaining({ signal: expect.any(AbortSignal) })
       )
     })
@@ -90,7 +86,6 @@ describe('BlueprintLink', () => {
     render(
       <BlueprintLink
         factionId="MLA"
-        unitId="tank"
         resourceName="/pa/units/land/tank/tank.json"
         displayName="View Blueprint"
       />

--- a/web/src/components/stats/AmmoSection.tsx
+++ b/web/src/components/stats/AmmoSection.tsx
@@ -7,16 +7,14 @@ import type { Ammo } from '@/types/faction';
 interface AmmoSectionProps {
   ammo: Ammo;
   factionId: string;
-  unitId: string;
 }
 
-export const AmmoSection: React.FC<AmmoSectionProps> = ({ ammo, factionId, unitId }) => {
+export const AmmoSection: React.FC<AmmoSectionProps> = ({ ammo, factionId }) => {
   return (
     <StatSection title="Ammo">
       <div className="py-1">
         <BlueprintLink
           factionId={factionId}
-          unitId={unitId}
           resourceName={ammo.resourceName}
           displayName="View Blueprint"
         />

--- a/web/src/components/stats/OverviewSection.tsx
+++ b/web/src/components/stats/OverviewSection.tsx
@@ -28,7 +28,6 @@ export const OverviewSection: React.FC<OverviewSectionProps> = ({ unit, factionI
       <div className="py-1">
         <BlueprintLink
           factionId={factionId}
-          unitId={unit.id}
           resourceName={unit.resourceName}
           displayName="View Blueprint"
         />

--- a/web/src/components/stats/WeaponSection.tsx
+++ b/web/src/components/stats/WeaponSection.tsx
@@ -7,10 +7,9 @@ import type { Weapon } from '@/types/faction';
 interface WeaponSectionProps {
   weapon: Weapon;
   factionId: string;
-  unitId: string;
 }
 
-export const WeaponSection: React.FC<WeaponSectionProps> = ({ weapon, factionId, unitId }) => {
+export const WeaponSection: React.FC<WeaponSectionProps> = ({ weapon, factionId }) => {
   const title = 'Weapon';
 
   // Format target layers
@@ -30,7 +29,6 @@ export const WeaponSection: React.FC<WeaponSectionProps> = ({ weapon, factionId,
       <div className="py-1">
         <BlueprintLink
           factionId={factionId}
-          unitId={unitId}
           resourceName={weapon.resourceName}
           displayName="View Blueprint"
         />

--- a/web/src/pages/UnitDetail.tsx
+++ b/web/src/pages/UnitDetail.tsx
@@ -96,13 +96,11 @@ export function UnitDetail() {
               <WeaponSection
                 weapon={weapon}
                 factionId={factionId || ''}
-                unitId={unitId || ''}
               />
               {weapon.ammoDetails && (
                 <AmmoSection
                   ammo={weapon.ammoDetails}
                   factionId={factionId || ''}
-                  unitId={unitId || ''}
                 />
               )}
             </React.Fragment>
@@ -113,13 +111,11 @@ export function UnitDetail() {
               <WeaponSection
                 weapon={selfDestructWeapon}
                 factionId={factionId || ''}
-                unitId={unitId || ''}
               />
               {selfDestructWeapon.ammoDetails && (
                 <AmmoSection
                   ammo={selfDestructWeapon.ammoDetails}
                   factionId={factionId || ''}
-                  unitId={unitId || ''}
                 />
               )}
             </>
@@ -130,13 +126,11 @@ export function UnitDetail() {
               <WeaponSection
                 weapon={deathExplosionWeapon}
                 factionId={factionId || ''}
-                unitId={unitId || ''}
               />
               {deathExplosionWeapon.ammoDetails && (
                 <AmmoSection
                   ammo={deathExplosionWeapon.ammoDetails}
                   factionId={factionId || ''}
-                  unitId={unitId || ''}
                 />
               )}
             </>


### PR DESCRIPTION
## What
Updates the web app's BlueprintLink component to generate paths using the new `assets/pa/...` folder structure.

## Why
The CLI now outputs faction data with spec files mirrored at `assets/pa/...` instead of `units/{unitId}/...`. The web app needs to match this structure to correctly link to blueprint files.

## Changes
- Updated BlueprintLink path generation to use assets/ structure
- Removed unused unitId prop from BlueprintLink component
- Removed unitId prop from OverviewSection, WeaponSection, and AmmoSection
- Updated UnitDetail page to reflect prop changes
- Updated BlueprintLink tests for new path structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)