### PR TITLE
feat(web): add visual distinction and collapsibility to stat sections

### DIFF
--- a/web/src/components/StatSection.test.tsx
+++ b/web/src/components/StatSection.test.tsx
@@ -23,9 +23,10 @@ describe('StatSection', () => {
 
     const button = screen.getByRole('button');
     expect(screen.getByText('Test content')).toBeInTheDocument();
+    expect(button).toHaveAttribute('aria-expanded', 'true');
 
     fireEvent.click(button);
-    expect(screen.queryByText('Test content')).not.toBeInTheDocument();
+    expect(button).toHaveAttribute('aria-expanded', 'false');
   });
 
   it('expands content when collapsed header is clicked', () => {
@@ -35,10 +36,11 @@ describe('StatSection', () => {
       </StatSection>
     );
 
-    expect(screen.queryByText('Test content')).not.toBeInTheDocument();
-
     const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+
     fireEvent.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'true');
     expect(screen.getByText('Test content')).toBeInTheDocument();
   });
 
@@ -50,7 +52,8 @@ describe('StatSection', () => {
     );
 
     expect(screen.getByText('Test Section')).toBeInTheDocument();
-    expect(screen.queryByText('Test content')).not.toBeInTheDocument();
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
   });
 
   it('has correct aria-expanded attribute', () => {
@@ -96,5 +99,19 @@ describe('StatSection', () => {
     const buttons = screen.getAllByRole('button');
     expect(buttons[0]).toHaveAttribute('aria-controls', 'section-content-first-section');
     expect(buttons[1]).toHaveAttribute('aria-controls', 'section-content-second-section');
+  });
+
+  it('shows appropriate tooltip based on expanded state', () => {
+    render(
+      <StatSection title="Test Section">
+        <div>Test content</div>
+      </StatSection>
+    );
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('title', 'Click to collapse');
+
+    fireEvent.click(button);
+    expect(button).toHaveAttribute('title', 'Click to expand');
   });
 });

--- a/web/src/components/StatSection.tsx
+++ b/web/src/components/StatSection.tsx
@@ -24,15 +24,16 @@ export const StatSection: React.FC<StatSectionProps> = ({
     <section className={`rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 ${className}`}>
       <button
         onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full flex items-center justify-between p-4 text-left hover:bg-gray-100 dark:hover:bg-gray-700/50 transition-colors rounded-t-lg"
+        className="group w-full flex items-center justify-between p-4 text-left hover:bg-gray-100 dark:hover:bg-gray-700/50 transition-colors rounded-t-lg"
         aria-expanded={isExpanded}
         aria-controls={contentId}
+        title={isExpanded ? 'Click to collapse' : 'Click to expand'}
       >
         <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
           {title}
         </h2>
         <svg
-          className={`w-5 h-5 text-gray-500 dark:text-gray-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+          className={`w-5 h-5 text-gray-500 dark:text-gray-400 transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
@@ -40,11 +41,17 @@ export const StatSection: React.FC<StatSectionProps> = ({
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
         </svg>
       </button>
-      {isExpanded && (
-        <dl id={contentId} className="space-y-2 px-4 pb-4">
-          {children}
-        </dl>
-      )}
+      <div
+        className={`grid transition-[grid-template-rows] duration-200 ease-in-out ${
+          isExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+        }`}
+      >
+        <div className="overflow-hidden">
+          <dl id={contentId} className="space-y-2 px-4 pb-4">
+            {children}
+          </dl>
+        </div>
+      </div>
     </section>
   );
 };


### PR DESCRIPTION
## What
Enhances StatSection components with card-like visual styling and collapsible functionality.

## Why
Improves the UnitDetail page organization and visual hierarchy. Users can now collapse sections they don't need, reducing visual clutter when viewing unit specifications.

## Changes
- Added card-like styling (border, background) to StatSection for better visual distinction
- Implemented collapsible toggle functionality with expand/collapse state
- Added tests for the collapsible behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)