### PR TITLE
fix(web): resolve GitHub Pages base path issues for routing and assets

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,7 +7,7 @@ import { UnitDetail } from '@/pages/UnitDetail'
 
 function App() {
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <ErrorBoundary>
         <FactionProvider>
           <div className="min-h-screen bg-background text-foreground">

--- a/web/src/services/factionLoader.ts
+++ b/web/src/services/factionLoader.ts
@@ -6,7 +6,7 @@ import {
   getLocalAssetUrl,
 } from './localFactionStorage'
 
-const FACTIONS_BASE_PATH = '/factions'
+const FACTIONS_BASE_PATH = `${import.meta.env.BASE_URL}factions`
 
 export interface FactionDiscoveryEntry {
   id: string


### PR DESCRIPTION
## What
Fixes base path configuration for React Router and asset fetching to work correctly on GitHub Pages.

## Why
The app failed to load on GitHub Pages with 404 errors for faction data and "No routes matched" error because the app is deployed to a subdirectory (/pa-pedia/) rather than the root path.

## Changes
- Added `basename={import.meta.env.BASE_URL}` to BrowserRouter in App.tsx
- Updated FACTIONS_BASE_PATH in factionLoader.ts to use `import.meta.env.BASE_URL`

This ensures the app works both locally (/) and on GitHub Pages (/pa-pedia/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)