### PR TITLE
fix(web): ensure consistent faction card heights on home page

### DIFF
--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -85,10 +85,10 @@ export function Home() {
       <div className="grid">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-6xl mx-auto">
           {factions.map((faction) => (
-            <div key={faction.folderName} className="relative group">
+            <div key={faction.folderName} className="relative group h-full">
               <Link
                 to={`/faction/${faction.folderName}`}
-                className="block p-6 border rounded-lg hover:border-primary transition-all hover:shadow-lg hover:shadow-primary/20"
+                className="block h-full p-6 border rounded-lg hover:border-primary transition-all hover:shadow-lg hover:shadow-primary/20 flex flex-col"
               >
                 <div className="flex items-start justify-between mb-2">
                   <div className="text-3xl font-display font-bold tracking-wide">{faction.displayName}</div>
@@ -98,8 +98,8 @@ export function Home() {
                     </span>
                   )}
                 </div>
-                <div className="text-sm text-muted-foreground mb-2 font-medium">{faction.description}</div>
-                <div className="text-xs text-muted-foreground font-mono">
+                <div className="text-sm text-muted-foreground mb-2 font-medium flex-grow">{faction.description}</div>
+                <div className="text-xs text-muted-foreground font-mono mt-auto">
                   {faction.author && `By ${faction.author} • `}
                   Version {faction.version}
                 </div>


### PR DESCRIPTION
## What
Fixed faction card height inconsistency on the Home page so all cards within each row have uniform height.

## Why
Faction cards with shorter descriptions were appearing smaller than those with longer descriptions, creating a visually inconsistent grid layout.

## Changes
- Added `h-full` to outer container div to stretch cards to match grid row height
- Added `h-full flex flex-col` to Link component for flexbox layout
- Added `flex-grow` to description div to expand and fill available vertical space
- Added `mt-auto` to version info to anchor it at the bottom of each card

🤖 Generated with [Claude Code](https://claude.com/claude-code)