### PR TITLE
fix(web): preserve comparison mode when changing primary unit

### DIFF
--- a/web/src/components/BreadcrumbNav.tsx
+++ b/web/src/components/BreadcrumbNav.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import Select from 'react-select'
 import type { StylesConfig } from 'react-select'
 import { useFactionContext } from '@/contexts/FactionContext'
@@ -96,6 +96,7 @@ const selectStyles: StylesConfig<SelectOption, false> = {
 
 export function BreadcrumbNav({ factionId, unitId, onUnitChange }: BreadcrumbNavProps) {
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
   const { factions, getFactionIndex, loadFaction } = useFactionContext()
 
   // Track selected faction for filtering units (may differ from URL during selection)
@@ -160,7 +161,12 @@ export function BreadcrumbNav({ factionId, unitId, onUnitChange }: BreadcrumbNav
       if (onUnitChange) {
         onUnitChange(selectedFactionId, option.value)
       } else {
-        navigate(`/faction/${selectedFactionId}/unit/${option.value}`)
+        // Preserve compare parameter when changing primary unit
+        const compareParam = searchParams.get('compare')
+        const url = compareParam
+          ? `/faction/${selectedFactionId}/unit/${option.value}?compare=${compareParam}`
+          : `/faction/${selectedFactionId}/unit/${option.value}`
+        navigate(url)
       }
     }
   }


### PR DESCRIPTION
## What
Preserves the compared unit selection when changing the primary unit in comparison mode on the unit detail page.

## Why
Previously, when viewing two units in comparison mode and selecting a different primary unit via the breadcrumb navigation, the compared unit would be lost. This required users to re-select the comparison unit each time they changed the primary unit, creating a poor user experience.

## Changes
- Added `useSearchParams` hook import to access URL query parameters
- Modified `handleUnitChange` to extract the `compare` query parameter
- Preserve the `compare` parameter in the navigation URL when switching primary units
- Only applies when not using custom `onUnitChange` callback (comparison mode uses default navigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)