### PR TITLE
fix: use sh -c for goreleaser before hook

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,7 +8,7 @@ project_name: pa-pedia
 
 before:
   hooks:
-    - cd cli && go mod tidy
+    - sh -c "cd cli && go mod tidy"
 
 builds:
   - id: pa-pedia


### PR DESCRIPTION
## Summary

Fixes the release workflow failure where `cd cli` couldn't be executed.

## Problem

GoReleaser doesn't execute hooks through a shell by default, so `cd` is not recognized as an executable:

```
error=hook failed: shell: 'cd cli': exec: "cd": executable file not found in $PATH
```

## Solution

Wrap the command in `sh -c "..."` to execute it through a shell:

```yaml
before:
  hooks:
    - sh -c "cd cli && go mod tidy"
```

## Test Plan

- [ ] Merge and verify the release workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)