### PR TITLE
fix: set build dir to cli for goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,7 +12,8 @@ before:
 
 builds:
   - id: pa-pedia
-    main: ./cli/main.go
+    dir: cli
+    main: .
     binary: pa-pedia
     env:
       - CGO_ENABLED=0


### PR DESCRIPTION
## Summary

Fixes the GoReleaser build failure where it couldn't find the Go module.

## Problem

GoReleaser runs from the repo root, but `go.mod` is in `cli/`. Using `main: ./cli/main.go` doesn't set the working directory, so the build fails:

```
no required module provides package github.com/jamiemulcahy/pa-pedia/cmd: go.mod file not found
```

## Solution

Use `dir: cli` to set the build working directory, then `main: .` to build from there:

```yaml
builds:
  - id: pa-pedia
    dir: cli
    main: .
```

## Test Plan

- [ ] Merge and verify release workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)