### PR TITLE
ci(deploy): add path filters to GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,9 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+    paths:
+      - 'web/**'
+      - 'schema/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What
Adds path filters to the GitHub Pages deployment workflow to trigger only on relevant file changes.

## Why
The current workflow triggers on every push to main, causing unnecessary deployments when files that don't affect the web app are changed (CLI code, documentation, etc.). This wastes GitHub Actions minutes and deployment resources.

## Changes
- Added `paths` filter to deploy.yml workflow
- Workflow now triggers only when files in `web/` or `schema/` directories change
- Manual `workflow_dispatch` trigger remains available for force deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)