### PR TITLE
fix(ci): exclude prerelease tags from version auto-increment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,8 +60,8 @@ jobs:
             echo "needs_tag=true" >> $GITHUB_OUTPUT
           else
             # Auto-increment: find latest tag and bump patch version
-            # Get latest tag matching vX.Y.Z pattern
-            LATEST_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1)
+            # Get latest stable tag matching vX.Y.Z pattern (exclude prereleases with hyphens)
+            LATEST_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1)
 
             if [[ -z "$LATEST_TAG" ]]; then
               # No tags exist, start at v0.1.0


### PR DESCRIPTION
## Summary
- Fixed release workflow incorrectly parsing prerelease tags like `v0.0.0-20251126-hash`
- Added grep filter to only match stable semver tags (`vX.Y.Z` without suffixes)
- Prevents malformed tags like `v0.0.-20251125` from being created

## Root Cause
The version detection at line 64 was matching prerelease tags. When parsing `v0.0.0-20251126-69b7351`:
- `PATCH` was set to `0-20251126-69b7351`
- Arithmetic increment `$((0-20251126-69b7351 + 1))` produced garbage

## Test plan
- [ ] Verify workflow passes CI
- [ ] Merge and confirm next release creates proper tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)