### PR TITLE
fix(web): use root base path for custom domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,8 +37,6 @@ jobs:
       - name: Build
         working-directory: web
         run: npm run build
-        env:
-          GITHUB_PAGES: 'true'
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -5,7 +5,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: process.env.GITHUB_PAGES ? '/pa-pedia/' : '/',
+  base: '/',
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary
- Fix 404 errors on custom domain pa-pedia.com by using `/` as base path instead of `/pa-pedia/`
- Remove unused `GITHUB_PAGES` environment variable from deploy workflow

## Test plan
- [ ] Verify site loads correctly at https://pa-pedia.com after merge
- [ ] Verify all assets (JS, CSS, images) load without 404s

🤖 Generated with [Claude Code](https://claude.com/claude-code)