### PR TITLE
fix(web): resolve URL redirect loop on custom domain

### DIFF
--- a/web/public/404.html
+++ b/web/public/404.html
@@ -6,7 +6,9 @@
     <script>
       // Single Page Apps for GitHub Pages
       // https://github.com/rafgraph/spa-github-pages
-      var pathSegmentsToKeep = 1;
+      // Set to 0 for custom domain at root path (pa-pedia.com)
+      // Use 1 if hosting at github.io/pa-pedia/
+      var pathSegmentsToKeep = 0;
 
       var l = window.location;
       l.replace(


### PR DESCRIPTION
## Summary
- Fixed `pathSegmentsToKeep` from 1 to 0 in 404.html SPA redirect handler
- The site is now hosted at pa-pedia.com (custom domain root) instead of github.io/pa-pedia/

## Problem
Opening faction pages in a new tab caused URLs to repeatedly append `/~and~/` patterns, creating an infinite redirect loop.

## Root Cause
The spa-github-pages redirect script was configured for subdirectory hosting (`pathSegmentsToKeep = 1`) but the site now uses a custom domain at root path.

## Test plan
- [ ] Open https://pa-pedia.com/faction/MLA in a new tab
- [ ] Verify URL stays stable without appending `/~and~/`
- [ ] Verify page loads correctly

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)