### PR TITLE
style(web): increase faction card background opacity

### DIFF
--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -70,7 +70,7 @@ function FactionCard({ faction, onDeleteClick }: FactionCardProps) {
         {/* Background image layer */}
         {backgroundUrl && (
           <div
-            className="absolute inset-0 bg-cover bg-center opacity-10"
+            className="absolute inset-0 bg-cover bg-center opacity-30"
             style={{ backgroundImage: `url(${backgroundUrl})` }}
           />
         )}


### PR DESCRIPTION
## What
Increased the background image opacity on faction cards from 10% to 30%.

## Why
The background images were too subtle at 10% opacity. Increasing to 30% makes the faction visual identity more prominent while still maintaining good text readability on the cards.

## Changes
- Updated faction card background image opacity from `opacity-10` to `opacity-30` in Home.tsx

🤖 Generated with [Claude Code](https://claude.com/claude-code)