### PR TITLE
fix(web): prevent scroll chaining in blueprint modal

### DIFF
--- a/web/src/components/BlueprintModal.tsx
+++ b/web/src/components/BlueprintModal.tsx
@@ -280,7 +280,8 @@ export const BlueprintModal: React.FC<BlueprintModalProps> = ({
           className="modal-content flex-1 overflow-auto p-4 relative min-h-0"
           style={{
             scrollbarWidth: 'thin',
-            scrollbarColor: isDarkMode ? '#4b5563 #1f2937' : '#9ca3af #e5e7eb'
+            scrollbarColor: isDarkMode ? '#4b5563 #1f2937' : '#9ca3af #e5e7eb',
+            overscrollBehavior: 'contain'
           }}
         >
           {loading && (


### PR DESCRIPTION
## Summary

- Add `overscrollBehavior: 'contain'` to the BlueprintModal's scrollable content area to prevent scroll events from bleeding through to the page

## Details

When scrolling within the blueprint modal reaches its limit, the scroll event was propagating to the background page. This is a common UX issue known as "scroll chaining".

The fix uses the CSS `overscroll-behavior: contain` property which stops scroll events from propagating when the inner scroll reaches its boundary.

Fixes #90

## Test plan

- [ ] Open a blueprint modal with scrollable content
- [ ] Scroll to the end of the content
- [ ] Continue scrolling - the background page should NOT scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)