### PR TITLE
refactor(web): update build power cost formula to include energy consumption

### DIFF
--- a/web/src/components/stats/EconomySection.tsx
+++ b/web/src/components/stats/EconomySection.tsx
@@ -39,11 +39,13 @@ export const EconomySection: React.FC<EconomySectionProps> = ({
   const compareBuildRange = compareEconomy?.buildRange;
 
   // Derived build arm stats
+  // Build power cost: total effective metal cost per unit of build rate
+  // Includes metal cost + energy consumption converted to metal equivalent (energy × 2/3)
   const costEffectiveness = buildRate > 0 && economy.buildCost > 0
-    ? economy.buildCost / buildRate
+    ? (economy.buildCost + energyConsumption * (2/3)) / buildRate
     : undefined;
   const compareCostEffectiveness = compareBuildRate && compareBuildRate > 0 && compareEconomy?.buildCost
-    ? compareEconomy.buildCost / compareBuildRate
+    ? (compareEconomy.buildCost + (compareEnergyConsumption || 0) * (2/3)) / compareBuildRate
     : undefined;
   const energyEfficiency = economy.buildInefficiency;
   const compareEnergyEfficiency = compareEconomy?.buildInefficiency;
@@ -181,13 +183,13 @@ export const EconomySection: React.FC<EconomySectionProps> = ({
       )}
       {costEffectiveness !== undefined && showRow(costEffDiff) && (
         <StatRow
-          label="Cost-effectiveness"
+          label="Build power cost"
           value={
             <ComparisonValue
               value={Number(costEffectiveness.toFixed(1))}
               compareValue={compareCostEffectiveness ? Number(compareCostEffectiveness.toFixed(1)) : undefined}
               comparisonType="lower-better"
-              suffix=" metal per metal/s"
+              suffix=" metal"
               hideDiff={hideDiff}
             />
           }

--- a/web/src/components/stats/__tests__/EconomySection.test.tsx
+++ b/web/src/components/stats/__tests__/EconomySection.test.tsx
@@ -119,12 +119,12 @@ describe('EconomySection', () => {
       expect(screen.getByText('60')).toBeInTheDocument()
     })
 
-    it('should render cost-effectiveness', () => {
+    it('should render build power cost', () => {
       render(<EconomySection economy={mockFabricatorEconomy} />)
 
-      expect(screen.getByText('Cost-effectiveness:')).toBeInTheDocument()
-      // 150 / 10 = 15
-      expect(screen.getByText('15 metal per metal/s')).toBeInTheDocument()
+      expect(screen.getByText('Build power cost:')).toBeInTheDocument()
+      // (150 + 1000 * 2/3) / 10 = (150 + 666.67) / 10 = 81.7
+      expect(screen.getByText('81.7 metal')).toBeInTheDocument()
     })
 
     it('should render energy efficiency', () => {
@@ -160,7 +160,7 @@ describe('EconomySection', () => {
       expect(screen.getByText('(-200 energy/s)')).toBeInTheDocument()
     })
 
-    it('should show comparison values for cost-effectiveness', () => {
+    it('should show comparison values for build power cost', () => {
       render(
         <EconomySection
           economy={mockFabricatorEconomy}
@@ -168,8 +168,9 @@ describe('EconomySection', () => {
         />
       )
 
-      // Cost-effectiveness: 150/10=15 vs 300/15=20, diff = -5 (lower is better)
-      expect(screen.getByText('(-5 metal per metal/s)')).toBeInTheDocument()
+      // Build power cost: (150 + 1000*2/3)/10=81.7 vs (300 + 1200*2/3)/15=73.3
+      // diff = 81.7 - 73.3 = 8.4 (higher is worse, so shows as +8.4)
+      expect(screen.getByText('(+8.4 metal)')).toBeInTheDocument()
     })
   })
 
@@ -204,9 +205,9 @@ describe('EconomySection', () => {
       }
       render(<EconomySection economy={economy} />)
 
-      // Should still render build rate but not cost-effectiveness
+      // Should still render build rate but not build power cost
       expect(screen.getByText('Build rate:')).toBeInTheDocument()
-      expect(screen.queryByText('Cost-effectiveness:')).not.toBeInTheDocument()
+      expect(screen.queryByText('Build power cost:')).not.toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
## What
Updated the build power cost calculation for fabricators to include both metal cost and energy consumption.

## Why
The original formula only considered the metal cost to build a fabricator, providing an incomplete picture of the actual investment required. The new formula includes energy consumption converted to metal equivalent (using a 2:3 energy-to-metal ratio based on power generator costs), giving users a more accurate understanding of total cost per unit of build power.

## Changes
- Updated formula from `buildCost / buildRate` to `(buildCost + energyConsumption × 2/3) / buildRate`
- Renamed label from "Cost-effectiveness" to "Build power cost" for clarity
- Changed suffix from "metal per metal/s" to "metal" to match the simplified metric
- Updated all related tests to reflect new calculation and expectations

Example impact (T2 Bot Fab):
- Old: 1800 / 45 = 40 metal per metal/s
- New: (1800 + 1800 × 2/3) / 45 = 66.7 metal

🤖 Generated with [Claude Code](https://claude.com/claude-code)