### PR TITLE
fix(web): resolve favicon 404 errors on nested routes

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="./favicon.png" />
+    <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>PA-Pedia - Planetary Annihilation Titans Database</title>
 


### PR DESCRIPTION
## What
Changes the favicon path from relative to absolute to prevent 404 errors on nested routes.

## Why
The favicon was configured with a relative path (`./favicon.png`), which caused 404 errors when users navigated to nested pages like `/faction/MLA/unit/tank`. The browser attempted to load the favicon from the nested path (e.g., `/faction/MLA/unit/favicon.png`) instead of the root (`/favicon.png`).

## Changes
- Updated `web/index.html` line 5: changed `href="./favicon.png"` to `href="/favicon.png"`

This ensures the favicon is always requested from the root of the site, regardless of the current route depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)