### PR TITLE
fix(ci): correct YAML indentation in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
             --title "Latest Release ($VERSION)" \
             --notes "This release always points to the latest stable version. Currently: $VERSION
 
-For changelog and details, see the [$VERSION release](https://github.com/${{ github.repository }}/releases/tag/$VERSION)." \
+          For changelog and details, see the [$VERSION release](https://github.com/${{ github.repository }}/releases/tag/$VERSION)." \
             latest-assets/*
 
           echo "Successfully updated 'latest' release to $VERSION"


### PR DESCRIPTION
The multiline string in the gh release create command had a line with no indentation inside a literal block scalar (run: |), which caused YAML parsing to fail. Added proper indentation to maintain the block's structure.