### PR TITLE
fix(web): correct splash damage label in UI

### DIFF
--- a/web/src/components/stats/AmmoSection.tsx
+++ b/web/src/components/stats/AmmoSection.tsx
@@ -61,7 +61,7 @@ export const AmmoSection: React.FC<AmmoSectionProps> = ({ ammo, compareAmmo, sho
       )}
       {ammo.splashDamage !== undefined && ammo.splashRadius !== undefined && showRow(splashDamageDiff) && (
         <StatRow
-          label="Burn damage"
+          label="Splash damage"
           value={
             <span>
               <ComparisonValue

--- a/web/src/components/stats/__tests__/AmmoSection.test.tsx
+++ b/web/src/components/stats/__tests__/AmmoSection.test.tsx
@@ -41,10 +41,10 @@ describe('AmmoSection', () => {
     expect(screen.getByText('100')).toBeInTheDocument()
   })
 
-  it('should render burn damage with radius', () => {
+  it('should render splash damage with radius', () => {
     renderAmmoSection({ ammo: mockAmmo })
 
-    expect(screen.getByText('Burn damage:')).toBeInTheDocument()
+    expect(screen.getByText('Splash damage:')).toBeInTheDocument()
     expect(screen.getByText('20')).toBeInTheDocument()
   })
 
@@ -100,8 +100,8 @@ describe('AmmoSection', () => {
       expect(screen.queryByText('Max velocity:')).not.toBeInTheDocument()
 
       // Splash radius is equal (5 vs 5), but splash damage differs (20 vs 25)
-      // so burn damage row should still show
-      expect(screen.getByText('Burn damage:')).toBeInTheDocument()
+      // so splash damage row should still show
+      expect(screen.getByText('Splash damage:')).toBeInTheDocument()
     })
 
     it('should return null when all values are equal and showDifferencesOnly is enabled', () => {


### PR DESCRIPTION
## What
Changed "Burn damage" to "Splash damage" in the AmmoSection component and updated corresponding test cases.

## Why
The PA game files use `splash_damage` and `splash_radius` fields, and the Go models correctly call them `SplashDamage` and `SplashRadius`. The UI was incorrectly labeling this as "Burn damage" when it should be "Splash damage" to match the actual game terminology.

## Changes
- Updated label in `web/src/components/stats/AmmoSection.tsx` (line 64)
- Updated test case names and assertions in `web/src/components/stats/__tests__/AmmoSection.test.tsx` to reflect the correct terminology