### PR TITLE
fix(web): prevent toggle button position shift on view mode change

### DIFF
--- a/web/src/pages/FactionDetail.tsx
+++ b/web/src/pages/FactionDetail.tsx
@@ -291,51 +291,8 @@ export function FactionDetail() {
           />
         </div>
         {/* Row 4 on mobile: All toggle buttons in one row, right-aligned on mobile */}
+        {/* Button order: grid-only buttons first, then persistent buttons last (so they don't shift when grid buttons disappear) */}
         <div className="flex gap-2 items-center justify-end sm:justify-start">
-          {/* View mode toggle */}
-          <button
-            type="button"
-            onClick={() => handleViewModeChange(viewMode === 'grid' ? 'table' : 'grid')}
-            className="p-2 border rounded-md bg-background hover:bg-muted transition-colors"
-            aria-label={viewMode === 'grid' ? 'Switch to table view' : 'Switch to grid view'}
-            title={viewMode === 'grid' ? 'Switch to table view' : 'Switch to grid view'}
-          >
-            {viewMode === 'grid' ? (
-              <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M3 14h18M3 6h18M3 18h18" />
-              </svg>
-            ) : (
-              <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
-              </svg>
-            )}
-          </button>
-          {/* Show inaccessible units toggle - only visible if there are inaccessible units */}
-          {inaccessibleCount > 0 && (
-            <button
-              type="button"
-              onClick={() => updatePreference('showInaccessible', !showInaccessible)}
-              className={`p-2 border rounded-md transition-colors ${
-                showInaccessible
-                  ? 'bg-primary text-primary-foreground border-primary'
-                  : 'bg-background hover:bg-muted'
-              }`}
-              aria-pressed={showInaccessible}
-              aria-label={showInaccessible ? 'Hide inaccessible units' : `Show ${inaccessibleCount} inaccessible units`}
-              title={showInaccessible ? 'Hide inaccessible units' : `Show ${inaccessibleCount} inaccessible units`}
-            >
-              {showInaccessible ? (
-                <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                </svg>
-              ) : (
-                <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
-                </svg>
-              )}
-            </button>
-          )}
           {/* Compact view toggle - only visible in grid mode */}
           {viewMode === 'grid' && (
             <button
@@ -395,6 +352,50 @@ export function FactionDetail() {
               </svg>
             </button>
           )}
+          {/* Show inaccessible units toggle - only visible if there are inaccessible units */}
+          {inaccessibleCount > 0 && (
+            <button
+              type="button"
+              onClick={() => updatePreference('showInaccessible', !showInaccessible)}
+              className={`p-2 border rounded-md transition-colors ${
+                showInaccessible
+                  ? 'bg-primary text-primary-foreground border-primary'
+                  : 'bg-background hover:bg-muted'
+              }`}
+              aria-pressed={showInaccessible}
+              aria-label={showInaccessible ? 'Hide inaccessible units' : `Show ${inaccessibleCount} inaccessible units`}
+              title={showInaccessible ? 'Hide inaccessible units' : `Show ${inaccessibleCount} inaccessible units`}
+            >
+              {showInaccessible ? (
+                <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                </svg>
+              ) : (
+                <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                </svg>
+              )}
+            </button>
+          )}
+          {/* View mode toggle - always visible, placed last so it stays in position */}
+          <button
+            type="button"
+            onClick={() => handleViewModeChange(viewMode === 'grid' ? 'table' : 'grid')}
+            className="p-2 border rounded-md bg-background hover:bg-muted transition-colors"
+            aria-label={viewMode === 'grid' ? 'Switch to table view' : 'Switch to grid view'}
+            title={viewMode === 'grid' ? 'Switch to table view' : 'Switch to grid view'}
+          >
+            {viewMode === 'grid' ? (
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M3 14h18M3 6h18M3 18h18" />
+              </svg>
+            ) : (
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
+              </svg>
+            )}
+          </button>
         </div>
       </div>
 


### PR DESCRIPTION
## What
Reordered toggle buttons in FactionDetail so that the view mode toggle button maintains its position when switching between grid and table views.

## Why
Previously, when clicking the table view toggle, grid-only buttons (compact view and show cost toggles) would disappear, causing the remaining persistent buttons to shift position due to `justify-end` alignment on mobile. This created a jarring UX where the button the user just clicked would move under their cursor.

## Changes
- Moved grid-only buttons (compact view, show cost) to appear first in the button row
- Moved persistent buttons (inaccessible toggle, view mode toggle) to appear last
- Added clarifying comment explaining the button order strategy
- Now when grid-only buttons disappear, persistent buttons remain anchored at the right edge

The view mode toggle now stays in a consistent position, making it easier for users to quickly switch between views without the button moving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)