### PR TITLE
feat(web): display weapon and ammo names in section headers

### DIFF
--- a/web/src/components/StatSection.tsx
+++ b/web/src/components/StatSection.tsx
@@ -2,6 +2,8 @@ import React, { useState, useMemo } from 'react';
 
 interface StatSectionProps {
   title: string;
+  /** Optional item name shown after title on larger screens (e.g., "Weapon: Uber Cannon") */
+  subtitle?: string;
   children: React.ReactNode;
   className?: string;
   defaultExpanded?: boolean;
@@ -9,6 +11,7 @@ interface StatSectionProps {
 
 export const StatSection: React.FC<StatSectionProps> = ({
   title,
+  subtitle,
   children,
   className = '',
   defaultExpanded = true
@@ -29,8 +32,16 @@ export const StatSection: React.FC<StatSectionProps> = ({
         aria-controls={contentId}
         title={isExpanded ? 'Click to collapse' : 'Click to expand'}
       >
-        <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
-          {title}
+        <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100 flex items-center min-w-0">
+          <span className="flex-shrink-0">{title}</span>
+          {subtitle && (
+            <span
+              className="hidden md:inline ml-1 font-normal text-gray-600 dark:text-gray-400 truncate"
+              title={subtitle}
+            >
+              : {subtitle}
+            </span>
+          )}
         </h2>
         <svg
           className={`w-5 h-5 text-gray-500 dark:text-gray-400 transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}

--- a/web/src/components/stats/AmmoSection.tsx
+++ b/web/src/components/stats/AmmoSection.tsx
@@ -21,6 +21,12 @@ export const AmmoSection: React.FC<AmmoSectionProps> = ({ ammo, compareAmmo, sho
   const { factionId: contextFactionId } = useCurrentFaction();
   const factionId = propFactionId || contextFactionId;
 
+  // Extract ammo ID from resource name (last part after last slash)
+  const ammoId = ammo.resourceName.split('/').pop() || ammo.resourceName;
+
+  // Display name: prefer explicit name, fall back to ammo ID
+  const displayName = ammo.name || ammoId;
+
   // Falloff weapons have splashRadius but no explicit splashDamage - use base damage for full damage at epicenter
   const getEffectiveSplashDamage = (a?: Ammo) =>
     a?.splashDamage ?? (a?.splashRadius ? a.damage : undefined);
@@ -48,7 +54,11 @@ export const AmmoSection: React.FC<AmmoSectionProps> = ({ ammo, compareAmmo, sho
   const showRow = (hasDiff: boolean) => !showDifferencesOnly || !compareAmmo || hasDiff;
 
   return (
-    <StatSection title="Ammo">
+    <StatSection title="Ammo" subtitle={displayName}>
+      {/* Show name on small screens where subtitle is hidden */}
+      <h3 className="text-lg font-semibold mb-3 text-gray-900 dark:text-gray-100 md:hidden">
+        {displayName}
+      </h3>
       <div className="py-1">
         <BlueprintLink
           resourceName={ammo.resourceName}

--- a/web/src/components/stats/WeaponSection.tsx
+++ b/web/src/components/stats/WeaponSection.tsx
@@ -51,6 +51,9 @@ export const WeaponSection: React.FC<WeaponSectionProps> = ({ weapon, compareWea
   // Extract weapon ID from resource name (last part after last slash)
   const weaponId = weapon.resourceName.split('/').pop() || weapon.resourceName;
 
+  // Display name: prefer explicit name, fall back to weapon ID
+  const displayName = weapon.name || weaponId;
+
   // Check which rows have differences
   const rangeDiff = isDifferent(weapon.maxRange, compareWeapon?.maxRange);
   const projDiff = isDifferent(weapon.projectilesPerFire, compareWeapon?.projectilesPerFire);
@@ -81,9 +84,10 @@ export const WeaponSection: React.FC<WeaponSectionProps> = ({ weapon, compareWea
   const showRow = (hasDiff: boolean) => !showDifferencesOnly || !compareWeapon || hasDiff;
 
   return (
-    <StatSection title={title}>
-      <h3 className="text-lg font-semibold mb-3 text-gray-900 dark:text-gray-100">
-        {weaponId}
+    <StatSection title={title} subtitle={displayName}>
+      {/* Show name on small screens where subtitle is hidden */}
+      <h3 className="text-lg font-semibold mb-3 text-gray-900 dark:text-gray-100 md:hidden">
+        {displayName}
       </h3>
       <div className="py-1">
         <BlueprintLink

--- a/web/src/components/stats/__tests__/WeaponSection.test.tsx
+++ b/web/src/components/stats/__tests__/WeaponSection.test.tsx
@@ -44,7 +44,8 @@ describe('WeaponSection', () => {
     it('should render weapon title', () => {
       renderWeaponSection(mockBasicWeapon)
 
-      expect(screen.getByText('tank_tool_weapon.json')).toBeInTheDocument()
+      // Weapon name is displayed (uses weapon.name when available, falls back to weapon ID)
+      expect(screen.getByText('Tank Cannon')).toBeInTheDocument()
     })
 
     it('should render damage', () => {

--- a/web/src/pages/__tests__/UnitDetail.test.tsx
+++ b/web/src/pages/__tests__/UnitDetail.test.tsx
@@ -94,8 +94,8 @@ describe('UnitDetail', () => {
       expect(screen.getByText('Weapon')).toBeInTheDocument()
     })
 
-    // Weapon ID is displayed as the title
-    expect(screen.getByText('tank_weapon.json')).toBeInTheDocument()
+    // Weapon name is displayed (uses weapon.name when available, falls back to weapon ID)
+    expect(screen.getByText('Main Cannon')).toBeInTheDocument()
     expect(screen.getByText('Range:')).toBeInTheDocument()
     // Value 100 appears multiple times, check it exists
     expect(screen.getAllByText('100').length).toBeGreaterThanOrEqual(1)

--- a/web/src/tests/integration/dataFlow.test.tsx
+++ b/web/src/tests/integration/dataFlow.test.tsx
@@ -95,7 +95,8 @@ describe('Data Flow Integration Tests', () => {
     renderApp('/faction/MLA/unit/tank')
 
     await waitFor(() => {
-      expect(screen.getByText('tank_weapon.json')).toBeInTheDocument()
+      // Weapon name is displayed (uses weapon.name when available)
+      expect(screen.getByText('Main Cannon')).toBeInTheDocument()
     })
 
     // Unit data comes from the index, so no additional fetch is needed
@@ -150,7 +151,8 @@ describe('Data Flow Integration Tests', () => {
     renderApp('/faction/MLA/unit/tank')
 
     await waitFor(() => {
-      expect(screen.getByText('tank_weapon.json')).toBeInTheDocument()
+      // Weapon name is displayed (uses weapon.name when available)
+      expect(screen.getByText('Main Cannon')).toBeInTheDocument()
     })
 
     // Verify unit data is displayed correctly - use heading for unique match
@@ -173,14 +175,16 @@ describe('Data Flow Integration Tests', () => {
     renderApp('/faction/MLA/unit/tank')
 
     await waitFor(() => {
-      expect(screen.getByText('tank_weapon.json')).toBeInTheDocument()
+      // Weapon name is displayed (uses weapon.name when available)
+      expect(screen.getByText('Main Cannon')).toBeInTheDocument()
     })
 
     // Load second unit
     renderApp('/faction/MLA/unit/bot')
 
     await waitFor(() => {
-      expect(screen.getByText('bot_weapon.json')).toBeInTheDocument()
+      // Weapon name is displayed (uses weapon.name when available)
+      expect(screen.getByText('Rifle')).toBeInTheDocument()
     })
 
     // Both units come from the same units.json fetch
@@ -201,9 +205,9 @@ describe('Data Flow Integration Tests', () => {
 
     // Both should load successfully
     await waitFor(() => {
-      // At least one should have loaded
+      // At least one should have loaded (check weapon names instead of weapon IDs)
       expect(
-        screen.queryByText('tank_weapon.json') || screen.queryByText('bot_weapon.json')
+        screen.queryByText('Main Cannon') || screen.queryByText('Rifle')
       ).toBeTruthy()
     })
   })
@@ -243,7 +247,8 @@ describe('Data Flow Integration Tests', () => {
     // Go to unit (unit data is in the index, no additional fetch)
     renderApp('/faction/MLA/unit/tank')
     await waitFor(() => {
-      expect(screen.getByText('tank_weapon.json')).toBeInTheDocument()
+      // Weapon name is displayed (uses weapon.name when available)
+      expect(screen.getByText('Main Cannon')).toBeInTheDocument()
     })
 
     // Verify order: metadata should be fetched before index
@@ -349,7 +354,8 @@ describe('Data Flow Integration Tests', () => {
     renderApp('/faction/MLA/unit/tank')
 
     await waitFor(() => {
-      expect(screen.getByText('tank_weapon.json')).toBeInTheDocument()
+      // Weapon name is displayed (uses weapon.name when available)
+      expect(screen.getByText('Main Cannon')).toBeInTheDocument()
     })
 
     // Verify the necessary fetches were made

--- a/web/src/tests/integration/navigation.test.tsx
+++ b/web/src/tests/integration/navigation.test.tsx
@@ -105,7 +105,8 @@ describe('Navigation Integration Tests', () => {
     // Step 3: Unit detail route (separate render to test route works)
     renderApp('/faction/MLA/unit/tank')
     await waitFor(() => {
-      expect(screen.getByText('tank_weapon.json')).toBeInTheDocument()
+      // Weapon name is displayed (uses weapon.name when available)
+      expect(screen.getByText('Main Cannon')).toBeInTheDocument()
       expect(screen.getByText(/back to faction/i)).toBeInTheDocument()
     })
   })
@@ -131,14 +132,16 @@ describe('Navigation Integration Tests', () => {
     renderApp('/faction/MLA/unit/tank')
 
     await waitFor(() => {
-      expect(screen.getByText('tank_weapon.json')).toBeInTheDocument()
+      // Weapon name is displayed (uses weapon.name when available)
+      expect(screen.getByText('Main Cannon')).toBeInTheDocument()
     })
 
     // Navigate to Bot unit
     renderApp('/faction/MLA/unit/bot')
 
     await waitFor(() => {
-      expect(screen.getByText('bot_weapon.json')).toBeInTheDocument()
+      // Weapon name is displayed (uses weapon.name when available)
+      expect(screen.getByText('Rifle')).toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
## What
Displays weapon and ammo names in collapsible section headers on medium and larger screens, providing better context when browsing unit specifications.

## Why
Previously, weapon and ammo sections only showed generic labels like "Weapon 1" or "Ammo" in the header. Users had to expand sections to see what weapon or ammo type they were looking at. Displaying the actual item names in the header improves readability and allows users to quickly identify specific weapons/ammo without expanding every section.

## Changes
- Added optional `subtitle` prop to `StatSection` component for displaying secondary text in headers
- `WeaponSection` now passes weapon display name as subtitle (using `name` field with fallback to resource ID)
- `AmmoSection` now displays ammo name and passes it as subtitle
- Names only appear in headers on md+ screens (responsive design)
- Long names are truncated with ellipsis and show full text on hover via tooltip
- On small screens, names continue to display inside section content for optimal mobile layout
- Updated all test files to expect weapon names instead of generic file IDs in assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)