### PR TITLE
fix(web): add pointer cursor to dropdown controls

### DIFF
--- a/web/src/components/FactionSelector.tsx
+++ b/web/src/components/FactionSelector.tsx
@@ -21,6 +21,7 @@ const selectStyles: StylesConfig<FactionOption, false> = {
   control: (base, state) => ({
     ...base,
     backgroundColor: 'rgb(31, 41, 55)', // gray-800
+    cursor: 'pointer',
     borderColor: state.isFocused ? 'rgb(59, 130, 246)' : 'rgb(75, 85, 99)', // blue-500 : gray-600
     borderRadius: '0.375rem',
     minHeight: '38px',

--- a/web/src/components/selectStyles.ts
+++ b/web/src/components/selectStyles.ts
@@ -15,6 +15,7 @@ export const selectStyles: StylesConfig<any, false> = {
   control: (base, state) => ({
     ...base,
     backgroundColor: 'rgb(31, 41, 55)', // gray-800
+    cursor: 'pointer',
     borderColor: state.isFocused ? 'rgb(59, 130, 246)' : 'rgb(75, 85, 99)', // blue-500 : gray-600
     borderRadius: '0.375rem',
     minHeight: '38px',


### PR DESCRIPTION
## What
Adds pointer cursor to dropdown/autocomplete control elements.

## Why
The select/dropdown controls did not show a pointer cursor when hovering over them, only the dropdown options did. This made the controls feel less interactive and created an inconsistent user experience.

## Changes
- Added `cursor: 'pointer'` to control style in `web/src/components/selectStyles.ts`
- Added `cursor: 'pointer'` to control style in `web/src/components/FactionSelector.tsx`

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)