### PR TITLE
fix(web): rename 'Projectiles per fire' to 'Projectiles per shot'

### DIFF
--- a/web/src/components/stats/WeaponSection.tsx
+++ b/web/src/components/stats/WeaponSection.tsx
@@ -99,7 +99,7 @@ export const WeaponSection: React.FC<WeaponSectionProps> = ({ weapon, compareWea
         <StatRow label="Range" value={weapon.maxRange} />
       )}
       {weapon.projectilesPerFire !== undefined && showRow(projDiff) && (
-        <StatRow label="Projectiles per fire" value={weapon.projectilesPerFire} />
+        <StatRow label="Projectiles per shot" value={weapon.projectilesPerFire} />
       )}
       {weapon.damage !== undefined && showRow(damageDiff) && (
         <StatRow


### PR DESCRIPTION
## Summary
- Renames weapon stats label from "Projectiles per fire" to "Projectiles per shot" for clarity and consistency with game terminology

Fixes #129

## Test plan
- [x] Build passes
- [x] All 601 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)