### PR TITLE
fix(cli): strip GitHub archive path prefix when copying files

### DIFF
--- a/cli/pkg/exporter/faction.go
+++ b/cli/pkg/exporter/faction.go
@@ -362,6 +362,12 @@ func (e *FactionExporter) copyFromZip(fileInfo *loader.UnitFileInfo, destPath st
 	// Clean path first to ensure consistent separators, then convert to forward slashes
 	normalizedFullPath := strings.TrimPrefix(filepath.ToSlash(filepath.Clean(fileInfo.FullPath)), "/")
 
+	// Strip any zip path prefix (e.g., "Exiles-Faction-main/" for GitHub archives)
+	// The zip index was built with prefixes stripped, so we need to strip here too
+	if prefix := source.ZipPathPrefix(); prefix != "" {
+		normalizedFullPath = strings.TrimPrefix(normalizedFullPath, prefix)
+	}
+
 	// Use zip index for O(1) lookup instead of O(n) scan
 	file, found := source.ZipIndex()[normalizedFullPath]
 	if !found {


### PR DESCRIPTION
## What
Fixes a bug where icons and other files from GitHub repository archives weren't being found during faction export.

## Why
When using GitHub repositories as mod sources (e.g., `github.com/NiklasKroworsch/Exiles`), the downloaded zip archives contain a top-level directory with the format `{repo}-{ref}/` (e.g., `Exiles-Faction-main/`). The zip index building code strips this prefix to create clean paths, but the file lookup code wasn't stripping the prefix when searching the index, causing O(1) lookups to fail and fall back to O(n) scans that still couldn't find the files.

## Changes
- Added `ZipPathPrefix()` getter method to `Source` struct in `cli/pkg/loader/loader.go`
- Updated `findFilesInZip()` to strip the prefix when normalizing zip entry paths for searching
- Updated `copyFromZip()` in `cli/pkg/exporter/faction.go` to strip the prefix before looking up files in the zip index
- Preserved original paths in `FullPath` for actual file access from the zip archive

This ensures consistent path handling: both index building and lookups use the same normalized paths (prefix stripped), while file access uses the original paths from the zip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)