### PR TITLE
fix(web): make page titles responsive - left on mobile, center on desktop

### DIFF
--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -11,7 +11,7 @@ export function Header({ onUploadClick, onDownloadClick }: HeaderProps) {
 
   return (
     <header className="sticky top-0 z-40 w-full bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b border-border">
-      <div className="flex items-center justify-between h-16 px-4">
+      <div className="relative flex items-center justify-between sm:justify-center h-16 px-4">
         {/* Center - Title and subtitle */}
         <Link
           to="/"
@@ -26,7 +26,7 @@ export function Header({ onUploadClick, onDownloadClick }: HeaderProps) {
         </Link>
 
         {/* Right - Actions */}
-        <div className="flex items-center gap-1 sm:w-32 justify-end">
+        <div className="flex items-center gap-1 sm:absolute sm:right-4 sm:w-32 justify-end">
           <a
             href={githubUrl}
             target="_blank"

--- a/web/src/pages/FactionDetail.tsx
+++ b/web/src/pages/FactionDetail.tsx
@@ -263,22 +263,24 @@ export function FactionDetail() {
       </div>
       <div className="mb-8">
         <Link to="/" className="text-primary hover:underline mb-4 inline-block font-medium">&larr; Back to factions</Link>
-        <div className="flex items-center gap-3 mb-2">
-          <h1 className="text-5xl font-display font-bold tracking-wide">
-            {isAllMode ? 'All' : metadata?.displayName}
-          </h1>
-          {!isAllMode && metadata?.isLocal && (
-            <span className="px-2 py-1 text-sm font-semibold bg-blue-600 text-white rounded">
-              LOCAL
-            </span>
-          )}
-        </div>
-        <p className="text-muted-foreground font-medium">
-          {isAllMode ? 'Browse units from all available factions' : metadata?.description}
-        </p>
-        <div className="text-sm text-muted-foreground mt-2 font-mono">
-          {filteredUnits.length} units{inaccessibleCount > 0 && !showInaccessible && ` (${inaccessibleCount} hidden)`}
-          {isAllMode && factionCount > 0 && ` from ${factionCount} factions`}
+        <div className="text-left md:text-center">
+          <div className="inline-flex items-center gap-3 mb-2">
+            <h1 className="text-5xl font-display font-bold tracking-wide">
+              {isAllMode ? 'All' : metadata?.displayName}
+            </h1>
+            {!isAllMode && metadata?.isLocal && (
+              <span className="px-2 py-1 text-sm font-semibold bg-blue-600 text-white rounded">
+                LOCAL
+              </span>
+            )}
+          </div>
+          <p className="text-muted-foreground font-medium">
+            {isAllMode ? 'Browse units from all available factions' : metadata?.description}
+          </p>
+          <div className="text-sm text-muted-foreground mt-2 font-mono">
+            {filteredUnits.length} units{inaccessibleCount > 0 && !showInaccessible && ` (${inaccessibleCount} hidden)`}
+            {isAllMode && factionCount > 0 && ` from ${factionCount} factions`}
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## What
Makes page titles responsive by aligning them to the left on mobile devices and centered on desktop screens.

## Why
The previous centered alignment on mobile pushed content too far to the right, creating an awkward layout on small screens. Left alignment is more natural for mobile reading patterns while centered titles work well on wider desktop displays.

## Changes
- **Header.tsx**: Changed flex container to use responsive justify (`justify-between` on mobile, `justify-center` on desktop sm+), positioned action buttons absolutely on desktop to prevent layout shift
- **FactionDetail.tsx**: Wrapped title section with responsive text alignment (`text-left` on mobile, `text-center` on desktop md+), used `inline-flex` to keep title and badge together

🤖 Generated with [Claude Code](https://claude.com/claude-code)