### PR TITLE
fix(web): filter build speed to units that can assist building target

### DIFF
--- a/web/src/components/stats/BuildsSection.tsx
+++ b/web/src/components/stats/BuildsSection.tsx
@@ -9,6 +9,8 @@ import type { UnitIndexEntry } from '@/types/faction';
 interface BuildsSectionProps {
   builds?: string[];
   buildRate: number;
+  /** Per-unit build rates (for group mode - only units that can build contribute) */
+  buildRateByUnit?: Record<string, number>;
   /** Optional faction ID override (used for comparison mode) */
   factionId?: string;
   /** Builds from the other unit (for showing diff on comparison side) */
@@ -34,6 +36,7 @@ interface BuildEntry {
 export const BuildsSection: React.FC<BuildsSectionProps> = ({
   builds,
   buildRate,
+  buildRateByUnit,
   factionId: propFactionId,
   compareBuilds,
   showDifferencesOnly,
@@ -83,7 +86,9 @@ export const BuildsSection: React.FC<BuildsSectionProps> = ({
       if (!targetUnit) return null;
 
       const buildCost = targetUnit.unit.specs.economy.buildCost || 0;
-      const buildTime = buildRate > 0 ? buildCost / buildRate : 0;
+      // Use per-unit build rate if available (group mode), otherwise use total build rate
+      const effectiveBuildRate = buildRateByUnit?.[unitId] ?? buildRate;
+      const buildTime = effectiveBuildRate > 0 ? buildCost / effectiveBuildRate : 0;
 
       return {
         id: unitId,

--- a/web/src/pages/UnitDetail.tsx
+++ b/web/src/pages/UnitDetail.tsx
@@ -767,6 +767,7 @@ export function UnitDetail() {
                           <BuildsSection
                             builds={primaryGroupStats.allBuilds}
                             buildRate={primaryGroupStats.totalBuildRate}
+                            buildRateByUnit={primaryGroupStats.buildRateByUnit}
                             compareBuilds={comparisonGroupStats?.allBuilds}
                           />
                         )}
@@ -776,6 +777,7 @@ export function UnitDetail() {
                           <BuildsSection
                             builds={comparisonGroupStats.allBuilds}
                             buildRate={comparisonGroupStats.totalBuildRate}
+                            buildRateByUnit={comparisonGroupStats.buildRateByUnit}
                             compareBuilds={primaryGroupStats?.allBuilds}
                             isComparisonSide
                           />

--- a/web/src/types/group.ts
+++ b/web/src/types/group.ts
@@ -117,6 +117,8 @@ export interface AggregatedGroupStats {
   allTargetLayers: string[]
   /** All unique unit IDs the group can build */
   allBuilds: string[]
+  /** Effective build rate for each buildable unit (only units that can build it contribute) */
+  buildRateByUnit: Record<string, number>
 
   // ===== GROUP metadata =====
   /** Total number of units (sum of quantities) */

--- a/web/src/utils/groupAggregation.ts
+++ b/web/src/utils/groupAggregation.ts
@@ -168,6 +168,8 @@ export function aggregateGroupStats(
   // SET aggregations (unique values across all units)
   const targetLayerSet = new Set<string>()
   const buildsSet = new Set<string>()
+  // Track build rate per buildable unit (only units that can build it contribute)
+  const buildRateByUnit: Record<string, number> = {}
 
   // Track total unit count
   let unitCount = 0
@@ -225,9 +227,12 @@ export function aggregateGroupStats(
       }
     }
 
-    // Collect buildable units
+    // Collect buildable units and track build rate per target
+    const unitBuildRate = (specs.economy.buildRate ?? 0) * qty
     for (const buildId of unit.buildRelationships?.builds ?? []) {
       buildsSet.add(buildId)
+      // Add this unit's build rate contribution for this target
+      buildRateByUnit[buildId] = (buildRateByUnit[buildId] ?? 0) + unitBuildRate
     }
 
     // Aggregate weapons
@@ -288,6 +293,7 @@ export function aggregateGroupStats(
     weapons,
     allTargetLayers: Array.from(targetLayerSet).sort(),
     allBuilds: Array.from(buildsSet).sort(),
+    buildRateByUnit,
     unitCount,
     distinctUnitTypes: units.length,
   }


### PR DESCRIPTION
## What
Filters build rate calculations in group mode to only include units that can actually assist building the target structure.

## Why
Fixes #178 - Build time calculations were using the total build rate from all units in the group, even for structures that most units cannot assist building. This resulted in incorrectly fast build times (e.g., showing pelters could be built in 0.15s when factories were in the group, even though factories cannot assist building pelters).

## Changes
- Add `buildRateByUnit` field to `AggregatedGroupStats` type to track build rate per buildable unit
- Update `groupAggregation` to track build rate per target, only including units that can build it
- Pass `buildRateByUnit` to `BuildsSection` in group mode
- Update build time calculation to use the filtered build rate for accurate results

🤖 Generated with [Claude Code](https://claude.com/claude-code)