### PR TITLE
fix(web): pass factionId to BuildsSection in group comparison mode

### DIFF
--- a/web/src/pages/UnitDetail.tsx
+++ b/web/src/pages/UnitDetail.tsx
@@ -947,24 +947,30 @@ export function UnitDetail() {
                             buildRate={primaryGroupStats.totalBuildRate}
                             buildRateByUnit={primaryGroupStats.buildRateByUnit}
                             compareBuilds={comparisonGroupStatsArray[0]?.allBuilds}
+                            factionId={primaryGroupMembers[0]?.factionId}
                           />
                         )}
                       </div>
-                      {comparisonGroupStatsArray.map((stats, groupIndex) => (
-                        <div key={`builds-${groupIndex}`} className="flex-1 min-w-[85vw] sm:min-w-[calc(33.333%-1rem)]">
-                          {stats && stats.allBuilds.length > 0 ? (
-                            <BuildsSection
-                              builds={stats.allBuilds}
-                              buildRate={stats.totalBuildRate}
-                              buildRateByUnit={stats.buildRateByUnit}
-                              compareBuilds={primaryGroupStats?.allBuilds}
-                              isComparisonSide
-                            />
-                          ) : (
-                            <div className="min-h-[50px]" />
-                          )}
-                        </div>
-                      ))}
+                      {comparisonGroupStatsArray.map((stats, groupIndex) => {
+                        const groupMembers = comparisonGroupMembersArray[groupIndex] || []
+                        const groupFactionId = groupMembers[0]?.factionId
+                        return (
+                          <div key={`builds-${groupIndex}`} className="flex-1 min-w-[85vw] sm:min-w-[calc(33.333%-1rem)]">
+                            {stats && stats.allBuilds.length > 0 ? (
+                              <BuildsSection
+                                builds={stats.allBuilds}
+                                buildRate={stats.totalBuildRate}
+                                buildRateByUnit={stats.buildRateByUnit}
+                                compareBuilds={primaryGroupStats?.allBuilds}
+                                isComparisonSide
+                                factionId={groupFactionId}
+                              />
+                            ) : (
+                              <div className="min-h-[50px]" />
+                            )}
+                          </div>
+                        )
+                      })}
                       {pendingComparisonGroupIndex >= comparisonGroups.length && (
                         <div className="flex-1 min-w-[85vw] sm:min-w-[calc(33.333%-1rem)]">
                           <div className="min-h-[50px]" />


### PR DESCRIPTION
## What
Fixes BuildsSection rendering empty builds in group comparison mode when comparing cross-faction units.

## Why
In group comparison mode, BuildsSection was not receiving the factionId prop, causing it to fall back to the primary unit's faction context from FactionContext. When comparing units from different factions (e.g., Legion factory vs MLA unit), the comparison group's builds section would render empty because it attempted to look up Legion unit IDs in MLA's unit list.

## Changes
- Pass factionId prop to BuildsSection for primary group from primaryGroupMembers[0]
- Pass factionId prop to BuildsSection for comparison groups from respective comparisonGroupMembersArray
- Extract groupFactionId from group members in comparison groups map

🤖 Generated with [Claude Code](https://claude.com/claude-code)