### PR TITLE
fix: use correct field name for download URL in manifest generation

### DIFF
--- a/scripts/generate-manifest.ts
+++ b/scripts/generate-manifest.ts
@@ -38,8 +38,7 @@ const ZIP_FILENAME_PATTERN = /^([A-Za-z0-9-]+)-([0-9.]+)-pedia(\d{14})\.zip$/
 interface ReleaseAsset {
   name: string
   size: number
-  url: string // API URL
-  browser_download_url: string // Direct download URL
+  url: string // Direct download URL (gh CLI returns this, not browser_download_url)
 }
 
 interface FactionMetadata {
@@ -79,7 +78,7 @@ interface Manifest {
  */
 function getReleaseAssets(): ReleaseAsset[] {
   const output = execSync(
-    `gh release view ${RELEASE_TAG} --json assets -q ".assets[] | {name, size, url, browser_download_url}"`,
+    `gh release view ${RELEASE_TAG} --json assets -q ".assets[] | {name, size, url}"`,
     { encoding: 'utf-8' }
   )
 
@@ -185,8 +184,8 @@ async function main() {
 
   for (const [key, zip] of factionMap) {
     const { factionId, version, timestamp } = zip.parsed!
-    // Use API-provided download URL instead of constructing manually
-    const downloadUrl = zip.asset.browser_download_url
+    // Use the download URL from gh CLI (it's in the 'url' field, not 'browser_download_url')
+    const downloadUrl = zip.asset.url
 
     console.log(`Processing ${factionId} v${version}...`)
 


### PR DESCRIPTION
## Summary
- Fixes metadata extraction failing with "Failed to parse URL from null" errors
- The `gh` CLI returns download URLs in the `url` field, not `browser_download_url`

## Root Cause
The previous review suggested using `browser_download_url` from the GitHub API, but the `gh` CLI maps this field to just `url`. The `browser_download_url` field doesn't exist in the `gh` CLI output, causing null values.

## Test plan
- [ ] Re-run the faction-data workflow manually
- [ ] Verify metadata is extracted successfully (no "Error extracting metadata" messages)
- [ ] Verify manifest.json includes displayName, build, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)