### PR TITLE
fix: serve faction data from GitHub Pages to avoid CORS issues

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - 'web/**'
       - 'schema/**'
+  # Also deploy when faction data is updated by the faction workflow
+  workflow_run:
+    workflows: ["Build and Release Faction Data"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -20,6 +25,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Skip if triggered by failed faction workflow
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -37,6 +44,25 @@ jobs:
       - name: Build
         working-directory: web
         run: npm run build
+
+      # Download faction data from GitHub Releases and include in dist
+      # This serves faction zips from the same origin, avoiding CORS issues
+      - name: Download faction data from release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p web/dist/factions
+
+          # Download all assets from the faction-data release
+          echo "Downloading faction data from release..."
+          gh release download faction-data --dir web/dist/factions --pattern "*.zip" --pattern "manifest.json" || {
+            echo "Warning: Could not download faction data from release"
+            echo "This is expected if the faction-data release doesn't exist yet"
+          }
+
+          # List what was downloaded
+          echo "Faction data downloaded:"
+          ls -la web/dist/factions/ || echo "No faction data found"
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/scripts/generate-manifest.ts
+++ b/scripts/generate-manifest.ts
@@ -184,13 +184,17 @@ async function main() {
 
   for (const [key, zip] of factionMap) {
     const { factionId, version, timestamp } = zip.parsed!
-    // Use the download URL from gh CLI (it's in the 'url' field, not 'browser_download_url')
-    const downloadUrl = zip.asset.url
+    // GitHub API URL for extracting metadata during generation
+    const ghDownloadUrl = zip.asset.url
 
     console.log(`Processing ${factionId} v${version}...`)
 
     // Extract metadata for build number and display name
-    const metadata = await extractMetadataFromZip(downloadUrl)
+    const metadata = await extractMetadataFromZip(ghDownloadUrl)
+
+    // Use relative path for downloadUrl - files are served from /factions/ on GitHub Pages
+    // This avoids CORS issues that would occur with GitHub Releases URLs
+    const downloadUrl = `/factions/${zip.asset.name}`
 
     entries.push({
       id: factionId,

--- a/web/src/services/manifestLoader.ts
+++ b/web/src/services/manifestLoader.ts
@@ -12,13 +12,15 @@
 
 import { getCachedManifestInfo, cacheManifestInfo } from './staticFactionCache'
 
-// Repository info - these should match your GitHub repo
-const REPO_OWNER = 'jamiemulcahy'
-const REPO_NAME = 'pa-pedia'
-const RELEASE_TAG = 'faction-data'
+// In production, faction data is served from the same origin (/factions/)
+// This avoids CORS issues that would occur with GitHub Releases URLs
+const FACTIONS_BASE_PATH = `${import.meta.env.BASE_URL}factions`
 
-// Manifest URL with cache-busting
-const MANIFEST_URL = `https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${RELEASE_TAG}/manifest.json`
+// Manifest URL - served from same origin in production
+const MANIFEST_URL = `${FACTIONS_BASE_PATH}/manifest.json`
+
+// Release tag for reference (used in cached manifest fallback)
+const RELEASE_TAG = 'faction-data'
 
 export interface ManifestEntry {
   id: string
@@ -150,11 +152,8 @@ export function isDevelopmentMode(): boolean {
 
 /**
  * Get the base path for faction data
- * In dev mode: local files; In prod: GitHub Releases
+ * Both dev and prod serve from the same origin at /factions/
  */
 export function getFactionBasePath(): string {
-  if (isDevelopmentMode()) {
-    return `${import.meta.env.BASE_URL}factions`
-  }
-  return `https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${RELEASE_TAG}`
+  return FACTIONS_BASE_PATH
 }


### PR DESCRIPTION
## Problem

Live site failing to load faction data with CORS error:
```
Access to fetch at 'https://github.com/.../releases/download/faction-data/manifest.json' 
from origin 'https://pa-pedia.com' has been blocked by CORS policy
```

GitHub Releases doesn't serve CORS headers, so browser JavaScript can't fetch files directly.

## Solution

Serve faction data from GitHub Pages (same origin as the app):

1. **Deploy workflow** downloads faction zips from releases and includes them in the Pages deployment
2. **Manifest URLs** are now relative (`/factions/MLA-1.0.0.zip`) instead of GitHub Releases URLs
3. **Workflow trigger** added to redeploy Pages when faction data updates

## Changes

- `.github/workflows/deploy.yml` - Download faction data and add to dist/factions/
- `web/src/services/manifestLoader.ts` - Use same-origin `/factions/` path
- `scripts/generate-manifest.ts` - Generate relative download URLs

## Testing

Once merged:
1. Faction workflow needs to run to regenerate manifest with new URLs
2. Deploy workflow will run automatically and include faction data
3. Site should load factions without CORS errors