### PR TITLE
fix: correct workflow name in deploy trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
       - 'schema/**'
   # Also deploy when faction data is updated by the faction workflow
   workflow_run:
-    workflows: ["Build and Release Faction Data"]
+    workflows: ["Faction Data Release"]
     types: [completed]
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
Fix workflow_run trigger to use correct name 'Faction Data Release' instead of 'Build and Release Faction Data'