### PR TITLE
feat(web): add explicit faction display ordering

### DIFF
--- a/web/src/hooks/useFactions.ts
+++ b/web/src/hooks/useFactions.ts
@@ -1,4 +1,5 @@
 import { useFactionContext } from '@/contexts/FactionContext'
+import { sortFactions } from '@/utils/factionOrdering'
 import type { FactionWithFolder } from '@/types/faction'
 
 /**
@@ -15,11 +16,13 @@ export function useFactions() {
     isLocalFaction,
   } = useFactionContext()
 
-  // Convert Map entries to array with folder names attached
-  const factionsList: FactionWithFolder[] = Array.from(factions.entries()).map(([folderName, metadata]) => ({
-    ...metadata,
-    folderName,
-  }))
+  // Convert Map entries to array with folder names attached, sorted by explicit order
+  const factionsList: FactionWithFolder[] = sortFactions(
+    Array.from(factions.entries()).map(([folderName, metadata]) => ({
+      ...metadata,
+      folderName,
+    }))
+  )
 
   return {
     factions: factionsList,

--- a/web/src/utils/factionOrdering.ts
+++ b/web/src/utils/factionOrdering.ts
@@ -1,0 +1,18 @@
+// Explicit faction display order (case-insensitive matching)
+const FACTION_ORDER = ['mla', 'legion', 'bugs', 'exiles', 'second-wave']
+
+export function sortFactions<T extends { folderName: string }>(factions: T[]): T[] {
+  return [...factions].sort((a, b) => {
+    const aIndex = FACTION_ORDER.indexOf(a.folderName.toLowerCase())
+    const bIndex = FACTION_ORDER.indexOf(b.folderName.toLowerCase())
+
+    // Both in order list: sort by defined order
+    if (aIndex !== -1 && bIndex !== -1) return aIndex - bIndex
+    // Only a in list: a comes first
+    if (aIndex !== -1) return -1
+    // Only b in list: b comes first
+    if (bIndex !== -1) return 1
+    // Neither in list: alphabetical by folderName
+    return a.folderName.localeCompare(b.folderName)
+  })
+}


### PR DESCRIPTION
## What
Implements a defined display order for factions on the Home page instead of relying on the order factions appear in the manifest.

## Why
The manifest order is generated from GitHub release assets, which don't maintain a consistent order. This results in factions appearing in a seemingly random order on the Home page. Users benefit from a predictable, logical ordering.

## Changes
- Created `web/src/utils/factionOrdering.ts` - utility module with `sortFactions` function
- Modified `web/src/hooks/useFactions.ts` - applies faction sorting before returning faction list
- Defined explicit order: MLA, Legion, Bugs, Exiles, Second-Wave
- Uses case-insensitive folder name matching for flexibility
- Factions not in the predefined list fall back to alphabetical sorting

🤖 Generated with [Claude Code](https://claude.com/claude-code)