### PR TITLE
fix(web): correct glob path for dev faction discovery

### DIFF
--- a/web/src/services/factionLoader.ts
+++ b/web/src/services/factionLoader.ts
@@ -44,8 +44,8 @@ export interface FactionDiscoveryEntry {
  */
 function discoverDevFactions(): string[] {
   // Use Vite's glob import to find all faction metadata files
-  // Path is relative to web/ folder - factions are at repo root ../factions/
-  const factionModules = import.meta.glob('../../factions/*/metadata.json')
+  // Path is relative to this file (web/src/services/) - factions are at repo root
+  const factionModules = import.meta.glob('../../../factions/*/metadata.json')
 
   // Extract faction IDs from the paths
   const factionIds: string[] = []


### PR DESCRIPTION
## Summary
- Fixed glob path in `factionLoader.ts` from `../../factions/*/metadata.json` to `../../../factions/*/metadata.json`
- The previous path resolved to `web/factions/` instead of the repo root `factions/` folder
- This was preventing factions from being discovered in development mode

## Test plan
- [x] Build passes
- [x] All 747 tests pass
- [ ] Run `npm run dev` and verify factions load on the home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)