### PR TITLE
fix(web): compare DPS like-for-like when one unit has sustained DPS

### DIFF
--- a/web/src/components/stats/OverviewSection.tsx
+++ b/web/src/components/stats/OverviewSection.tsx
@@ -86,6 +86,11 @@ export const OverviewSection: React.FC<OverviewSectionProps> = ({
     ?.filter(w => w.maxRange !== undefined)
     .reduce((max, w) => Math.max(max, w.maxRange || 0), 0));
 
+  // Check if comparison unit has sustained DPS that differs from burst
+  const compareHasSustainedDps = compareSustainedDps !== undefined &&
+    compareDps !== undefined &&
+    compareSustainedDps !== compareDps;
+
   // Unit-only: build locations
   const buildLocations: string[] = [];
   if (!isGroupMode && unit) {
@@ -181,8 +186,12 @@ export const OverviewSection: React.FC<OverviewSectionProps> = ({
             <ComparisonValue
               value={Number((hasSustainedDps ? sustainedDps! : dps).toFixed(1))}
               compareValue={
-                hasSustainedDps
-                  ? (compareSustainedDps !== undefined ? Number(compareSustainedDps.toFixed(1)) : undefined)
+                // Compare "effective" DPS: sustained DPS if available (either unit), else burst
+                // This ensures like-for-like comparison (sustained vs sustained, not burst vs sustained)
+                hasSustainedDps || compareHasSustainedDps
+                  ? (compareSustainedDps !== undefined
+                      ? Number(compareSustainedDps.toFixed(1))
+                      : (compareDps !== undefined ? Number(compareDps.toFixed(1)) : undefined))
                   : (compareDps !== undefined ? Number(compareDps.toFixed(1)) : undefined)
               }
               comparisonType="higher-better"

--- a/web/src/components/stats/__tests__/OverviewSection.test.tsx
+++ b/web/src/components/stats/__tests__/OverviewSection.test.tsx
@@ -210,5 +210,31 @@ describe('OverviewSection', () => {
       // Should show sustained DPS comparison (60 vs 90 = -30)
       expect(screen.getByText('(-30)')).toBeInTheDocument()
     })
+
+    it('should compare burst DPS to comparison sustained DPS when current has no sustained (#205)', () => {
+      // This tests the fix for bug #205:
+      // When a unit without sustained DPS (Dox) is compared against a unit with sustained DPS (Cub),
+      // it should compare burst DPS vs sustained DPS, not burst vs burst
+
+      // Simulating: Dox (DPS: 50) vs Cub (sustained: 60, burst: 100)
+      // Should show: 50 vs 60 = -10, NOT 50 vs 100 = -50
+
+      renderOverviewSection(mockUnit, mockUnitWithAmmoWeapon)
+
+      // mockUnit has DPS: 50, mockUnitWithAmmoWeapon has sustained DPS: 60, burst: 100
+      // Comparison should be 50 vs 60 = -10
+      expect(screen.getByText('(-10)')).toBeInTheDocument()
+    })
+
+    it('should compare sustained DPS to comparison burst DPS when comparison has no sustained', () => {
+      // Reverse case: unit with sustained compared to unit without sustained
+      // mockUnitWithAmmoWeapon (sustained: 60) vs mockUnit (DPS: 50)
+      // Should show: 60 vs 50 = +10
+
+      renderOverviewSection(mockUnitWithAmmoWeapon, mockUnit)
+
+      // Comparison should be 60 vs 50 = +10
+      expect(screen.getByText('(+10)')).toBeInTheDocument()
+    })
   })
 })


### PR DESCRIPTION
## Summary

- Fix DPS comparison showing incorrect differences when comparing units with/without sustained DPS
- When either unit has sustained DPS, compare against the "effective" DPS (sustained if available)
- Add test cases for the cross-comparison scenarios

## Problem

When comparing Cub (Exiles) vs Dox (MLA):
- Cub has sustained DPS (239.9) and burst DPS (1800)
- Dox has just regular DPS (252)

**Before:** Dox showed "252 (-1548)" because it compared against Cub's burst DPS (1800)
**After:** Dox shows "252 (+12)" because it compares against Cub's sustained DPS (239.9)

## Solution

Updated `OverviewSection.tsx` to check if the comparison unit has sustained DPS even when the current unit doesn't, and use the sustained value for like-for-like comparison.

The logic now:
- If either unit has sustained DPS → compare current's DPS against comparison's sustained (or burst if unavailable)
- If neither has sustained DPS → compare burst vs burst (unchanged)

## Test plan

- [x] Build succeeds
- [x] All existing tests pass
- [x] New test cases added for:
  - Unit without sustained vs unit with sustained (the bug scenario)
  - Unit with sustained vs unit without sustained (reverse case)

Fixes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)