### PR TITLE
feat: update Bugs profile to use GitHub source repos

### DIFF
--- a/cli/profiles/embedded/bugs.json
+++ b/cli/profiles/embedded/bugs.json
@@ -1,6 +1,9 @@
 {
   "displayName": "Bugs",
   "factionUnitType": "Custom2",
-  "mods": ["com.pa.ferretmaster.bugs", "com.pa.ferretmaster.bugs-client"],
+  "mods": [
+    "github.com/Ferret-Master/Bug-Faction/tree/main",
+    "github.com/Ferret-Master/Bug-Faction-Client/tree/main"
+  ],
   "backgroundImage": "ui/mods/bugs_faction/img/Bug_Menu.png"
 }

--- a/factions/Bugs/assets/pa/units/structure/control_node/portal/portal_ammo.json
+++ b/factions/Bugs/assets/pa/units/structure/control_node/portal/portal_ammo.json
@@ -1,0 +1,98 @@
+{
+    "display_name": "!LOC:Portal Charge",
+    "description": "!LOC:Portal Charge - Long range interplanetary, charges a portal upon landing which lasts for 60 seconds if not destroyed",
+    "ammo_type": "Projectile",
+
+    "audio_loop": "/SE/Weapons/commander/Commander_uber_cannon_fire",
+    "build_metal_cost": 5000,
+    "collision_check": "ground",
+    "cruise_height": 150,
+    "damage": 0,
+    "splash_damage": 0,
+    "splash_radius": 60,
+    "enable_orbital_shell": true,
+    "events": {
+      "collided": {
+        "audio_cue": "/SE/Impacts/missile_seeking",
+        "effect_spec": "/pa/units/air/missile_nuke/missile_nuke_implosion.pfx",
+        "effect_world_aligned": false
+      }
+    },
+    "flight_type": "Staged",
+    "fx_trail": {
+      "filename": "/pa/units/structure/control_node/portal/portal_proj.pfx",
+      "offset": [
+        0.0,
+        12.0,
+        0.0
+      ]
+    },
+    "gravwell_velocity_multiplier": 10.0,
+    "has_notifications": true,
+    "influence_radius": 3200,
+    "initial_velocity": 80.0,
+    "interplanetary_type": "INTER_System",
+    "lifetime": 0,
+    "max_velocity": 150.0,
+    "model": {
+      "filename": "/pa/units/air/missile_nuke/missile_nuke.papa"
+    },
+    "physics": {
+      "radius": 10,
+      "gravity_scalar": 3,
+      "ignore_gravity": true,
+      "add_to_spatial_db": true,
+      "allow_underground": true
+    },
+    "recon": {
+      "observable": {
+        "ignore_radar": false
+      }
+    },
+    "show_in_orbital_layer": true,
+    "show_strategic_icon": true,
+    "si_name": "nuke_launcher_ammo",
+    "signal_type": "nuke",
+    "spawn_layers": "WL_Air",
+    "stage_on_planet_handoff": 2,
+    "stages": [
+      {
+        "ignores_gravity": true,
+        "ignores_LOS": true,
+        "stage_duration": 600,
+        "stage_turn_rate": 0,
+        "rotates_to_velocity": true
+      },
+      {
+        "ignores_gravity": true,
+        "ignores_LOS": true,
+        "stage_duration": 0,
+        "stage_turn_rate": 90,
+        "stage_change_range": 75,
+        "rotates_to_velocity": true
+      },
+      {
+        "ignores_gravity": false,
+        "ignores_LOS": false,
+        "stage_duration": 5000,
+        "stage_turn_rate": 90,
+        "rotates_to_velocity": true
+      },
+      {
+        "ignores_gravity": false,
+        "ignores_LOS": false,
+        "stage_duration": 5000,
+        "stage_turn_rate": 1080,
+        "rotates_to_velocity": true
+      }
+    ],
+    "system_velocity_multiplier": 60.0,
+    "turn_rate": 180,
+    "spawn_unit_on_death": "/pa/units/structure/control_node/portal/portal_charging.json",
+    "spawn_unit_on_death_with_velocity": false,
+    "unit_types": [
+      "UNITTYPE_Mobile",
+      "UNITTYPE_Orbital",
+      "UNITTYPE_Interplanetary"
+    ]
+  }

--- a/factions/Bugs/metadata.json
+++ b/factions/Bugs/metadata.json
@@ -8,8 +8,8 @@
   "build": "120799",
   "type": "mod",
   "mods": [
-    "com.pa.ferretmaster.bugs",
-    "com.pa.ferretmaster.bugs-client"
+    "github.com/Ferret-Master/Bug-Faction/tree/main",
+    "github.com/Ferret-Master/Bug-Faction-Client/tree/main"
   ],
   "backgroundImage": "assets/ui/mods/bugs_faction/img/Bug_Menu.png"
 }

--- a/factions/Bugs/units.json
+++ b/factions/Bugs/units.json
@@ -1633,72 +1633,6 @@
       }
     },
     {
-      "identifier": "bug_boomer_mine_unlock",
-      "displayName": "Bug Boomer Mine Unlock",
-      "unitTypes": [
-        "Bot",
-        "Basic",
-        "SelfDestruct",
-        "FactoryBuild",
-        "Custom2"
-      ],
-      "source": "pa",
-      "files": [
-        {
-          "path": "pa/units/research/unlocks/bug_boomer_mine_unlock/bug_boomer_mine_unlock.json",
-          "source": "com.pa.ferretmaster.bugs"
-        },
-        {
-          "path": "/pa/units/research/unlocks/bug_boomer_mine_unlock/bug_boomer_mine_unlock_icon_buildbar.png",
-          "source": "com.pa.ferretmaster.bugs"
-        }
-      ],
-      "unit": {
-        "id": "bug_boomer_mine_unlock",
-        "resourceName": "/pa/units/research/unlocks/bug_boomer_mine_unlock/bug_boomer_mine_unlock.json",
-        "displayName": "Bug Boomer Mine Unlock",
-        "description": "Allows boomers to alt fire and make mines where they stand and vise versa",
-        "image": "assets/pa/units/research/unlocks/bug_boomer_mine_unlock/bug_boomer_mine_unlock_icon_buildbar.png",
-        "tier": 1,
-        "unitTypes": [
-          "Bot",
-          "Basic",
-          "SelfDestruct",
-          "FactoryBuild",
-          "Custom2"
-        ],
-        "accessible": true,
-        "specs": {
-          "combat": {
-            "health": 1
-          },
-          "economy": {
-            "buildCost": 200,
-            "production": {},
-            "consumption": {},
-            "storage": {},
-            "toolConsumption": {},
-            "weaponConsumption": {}
-          },
-          "mobility": {
-            "turnSpeed": 1,
-            "acceleration": 1,
-            "brake": 1
-          },
-          "recon": {
-            "visionRadius": 100
-          },
-          "storage": {},
-          "special": {}
-        },
-        "buildRelationships": {
-          "builtBy": [
-            "research_boomer_mine"
-          ]
-        }
-      }
-    },
-    {
       "identifier": "research_boomer_mine",
       "displayName": "Bug Boomer Mine Unlock",
       "unitTypes": [
@@ -1799,6 +1733,72 @@
           ]
         },
         "buildableTypes": "(Custom2 \u0026 FactoryBuild \u0026 Basic \u0026 Bot \u0026 SelfDestruct) - Mobile"
+      }
+    },
+    {
+      "identifier": "bug_boomer_mine_unlock",
+      "displayName": "Bug Boomer Mine Unlock",
+      "unitTypes": [
+        "Bot",
+        "Basic",
+        "SelfDestruct",
+        "FactoryBuild",
+        "Custom2"
+      ],
+      "source": "pa",
+      "files": [
+        {
+          "path": "pa/units/research/unlocks/bug_boomer_mine_unlock/bug_boomer_mine_unlock.json",
+          "source": "com.pa.ferretmaster.bugs"
+        },
+        {
+          "path": "/pa/units/research/unlocks/bug_boomer_mine_unlock/bug_boomer_mine_unlock_icon_buildbar.png",
+          "source": "com.pa.ferretmaster.bugs"
+        }
+      ],
+      "unit": {
+        "id": "bug_boomer_mine_unlock",
+        "resourceName": "/pa/units/research/unlocks/bug_boomer_mine_unlock/bug_boomer_mine_unlock.json",
+        "displayName": "Bug Boomer Mine Unlock",
+        "description": "Allows boomers to alt fire and make mines where they stand and vise versa",
+        "image": "assets/pa/units/research/unlocks/bug_boomer_mine_unlock/bug_boomer_mine_unlock_icon_buildbar.png",
+        "tier": 1,
+        "unitTypes": [
+          "Bot",
+          "Basic",
+          "SelfDestruct",
+          "FactoryBuild",
+          "Custom2"
+        ],
+        "accessible": true,
+        "specs": {
+          "combat": {
+            "health": 1
+          },
+          "economy": {
+            "buildCost": 200,
+            "production": {},
+            "consumption": {},
+            "storage": {},
+            "toolConsumption": {},
+            "weaponConsumption": {}
+          },
+          "mobility": {
+            "turnSpeed": 1,
+            "acceleration": 1,
+            "brake": 1
+          },
+          "recon": {
+            "visionRadius": 100
+          },
+          "storage": {},
+          "special": {}
+        },
+        "buildRelationships": {
+          "builtBy": [
+            "research_boomer_mine"
+          ]
+        }
       }
     },
     {
@@ -3480,37 +3480,6 @@
             "salvoDamage": 500,
             "weapons": [
               {
-                "resourceName": "/pa/units/orbital/ion_defense/ion_defense_tool_weapon.json",
-                "safeName": "ion_defense_tool_weapon",
-                "name": "ion_defense_tool_weapon",
-                "count": 1,
-                "rateOfFire": 2,
-                "damage": 100,
-                "dps": 200,
-                "projectilesPerFire": 1,
-                "muzzleVelocity": 1000,
-                "maxRange": 300,
-                "targetLayers": [
-                  "Orbital"
-                ],
-                "targetPriorities": [
-                  "Orbital"
-                ],
-                "yawRange": 180,
-                "yawRate": 180,
-                "pitchRange": 180,
-                "pitchRate": 180,
-                "ammoDetails": {
-                  "resourceName": "/pa/units/orbital/ion_defense/ion_defense_ammo.json",
-                  "safeName": "ion_defense_ammo",
-                  "name": "ion_defense_ammo",
-                  "damage": 100,
-                  "muzzleVelocity": 1000,
-                  "maxVelocity": 1000,
-                  "lifetime": 3
-                }
-              },
-              {
                 "resourceName": "/pa/units/orbital/ion_defense/ion_defense_tool_antidrop.json",
                 "safeName": "ion_defense_tool_antidrop",
                 "name": "ion_defense_tool_antidrop",
@@ -3538,6 +3507,37 @@
                   "damage": 400,
                   "muzzleVelocity": 10,
                   "maxVelocity": 400,
+                  "lifetime": 3
+                }
+              },
+              {
+                "resourceName": "/pa/units/orbital/ion_defense/ion_defense_tool_weapon.json",
+                "safeName": "ion_defense_tool_weapon",
+                "name": "ion_defense_tool_weapon",
+                "count": 1,
+                "rateOfFire": 2,
+                "damage": 100,
+                "dps": 200,
+                "projectilesPerFire": 1,
+                "muzzleVelocity": 1000,
+                "maxRange": 300,
+                "targetLayers": [
+                  "Orbital"
+                ],
+                "targetPriorities": [
+                  "Orbital"
+                ],
+                "yawRange": 180,
+                "yawRate": 180,
+                "pitchRange": 180,
+                "pitchRate": 180,
+                "ammoDetails": {
+                  "resourceName": "/pa/units/orbital/ion_defense/ion_defense_ammo.json",
+                  "safeName": "ion_defense_ammo",
+                  "name": "ion_defense_ammo",
+                  "damage": 100,
+                  "muzzleVelocity": 1000,
+                  "maxVelocity": 1000,
                   "lifetime": 3
                 }
               }
@@ -4061,70 +4061,6 @@
       }
     },
     {
-      "identifier": "bug_needler_fast_unlock",
-      "displayName": "Fast Needler Unlock",
-      "unitTypes": [
-        "Tank",
-        "Basic",
-        "FactoryBuild",
-        "Custom2"
-      ],
-      "source": "pa",
-      "files": [
-        {
-          "path": "pa/units/research/unlocks/bug_needler_fast_unlock/bug_needler_fast_unlock.json",
-          "source": "com.pa.ferretmaster.bugs"
-        },
-        {
-          "path": "/pa/units/research/unlocks/bug_needler_fast_unlock/bug_needler_fast_unlock_icon_buildbar.png",
-          "source": "com.pa.ferretmaster.bugs"
-        }
-      ],
-      "unit": {
-        "id": "bug_needler_fast_unlock",
-        "resourceName": "/pa/units/research/unlocks/bug_needler_fast_unlock/bug_needler_fast_unlock.json",
-        "displayName": "Fast Needler Unlock",
-        "description": "Raises the needler speed from 14 to 16",
-        "image": "assets/pa/units/research/unlocks/bug_needler_fast_unlock/bug_needler_fast_unlock_icon_buildbar.png",
-        "tier": 1,
-        "unitTypes": [
-          "Tank",
-          "Basic",
-          "FactoryBuild",
-          "Custom2"
-        ],
-        "accessible": true,
-        "specs": {
-          "combat": {
-            "health": 1
-          },
-          "economy": {
-            "buildCost": 400,
-            "production": {},
-            "consumption": {},
-            "storage": {},
-            "toolConsumption": {},
-            "weaponConsumption": {}
-          },
-          "mobility": {
-            "turnSpeed": 1,
-            "acceleration": 1,
-            "brake": 1
-          },
-          "recon": {
-            "visionRadius": 100
-          },
-          "storage": {},
-          "special": {}
-        },
-        "buildRelationships": {
-          "builtBy": [
-            "research_needler"
-          ]
-        }
-      }
-    },
-    {
       "identifier": "research_needler",
       "displayName": "Fast Needler Unlock",
       "unitTypes": [
@@ -4227,6 +4163,70 @@
           ]
         },
         "buildableTypes": "(Custom2 \u0026 FactoryBuild \u0026 Basic \u0026 Tank) - Mobile"
+      }
+    },
+    {
+      "identifier": "bug_needler_fast_unlock",
+      "displayName": "Fast Needler Unlock",
+      "unitTypes": [
+        "Tank",
+        "Basic",
+        "FactoryBuild",
+        "Custom2"
+      ],
+      "source": "pa",
+      "files": [
+        {
+          "path": "pa/units/research/unlocks/bug_needler_fast_unlock/bug_needler_fast_unlock.json",
+          "source": "com.pa.ferretmaster.bugs"
+        },
+        {
+          "path": "/pa/units/research/unlocks/bug_needler_fast_unlock/bug_needler_fast_unlock_icon_buildbar.png",
+          "source": "com.pa.ferretmaster.bugs"
+        }
+      ],
+      "unit": {
+        "id": "bug_needler_fast_unlock",
+        "resourceName": "/pa/units/research/unlocks/bug_needler_fast_unlock/bug_needler_fast_unlock.json",
+        "displayName": "Fast Needler Unlock",
+        "description": "Raises the needler speed from 14 to 16",
+        "image": "assets/pa/units/research/unlocks/bug_needler_fast_unlock/bug_needler_fast_unlock_icon_buildbar.png",
+        "tier": 1,
+        "unitTypes": [
+          "Tank",
+          "Basic",
+          "FactoryBuild",
+          "Custom2"
+        ],
+        "accessible": true,
+        "specs": {
+          "combat": {
+            "health": 1
+          },
+          "economy": {
+            "buildCost": 400,
+            "production": {},
+            "consumption": {},
+            "storage": {},
+            "toolConsumption": {},
+            "weaponConsumption": {}
+          },
+          "mobility": {
+            "turnSpeed": 1,
+            "acceleration": 1,
+            "brake": 1
+          },
+          "recon": {
+            "visionRadius": 100
+          },
+          "storage": {},
+          "special": {}
+        },
+        "buildRelationships": {
+          "builtBy": [
+            "research_needler"
+          ]
+        }
       }
     },
     {
@@ -7499,7 +7499,7 @@
       }
     },
     {
-      "identifier": "bug_wall_acid",
+      "identifier": "turret_acid_dot",
       "displayName": "bug bomber dot",
       "unitTypes": [
         "Structure",
@@ -7513,13 +7513,13 @@
       "source": "pa",
       "files": [
         {
-          "path": "pa/units/structure/bug_wall/bug_wall_acid.json",
+          "path": "pa/units/structure/bug_turret_acid/turret_acid_dot.json",
           "source": "com.pa.ferretmaster.bugs"
         }
       ],
       "unit": {
-        "id": "bug_wall_acid",
-        "resourceName": "/pa/units/structure/bug_wall/bug_wall_acid.json",
+        "id": "turret_acid_dot",
+        "resourceName": "/pa/units/structure/bug_turret_acid/turret_acid_dot.json",
         "displayName": "bug bomber dot",
         "description": "Land Mine - damage over time unit",
         "tier": 1,
@@ -7535,14 +7535,14 @@
         "accessible": false,
         "specs": {
           "combat": {
-            "health": 140,
+            "health": 100,
             "dps": 30,
             "salvoDamage": 5,
             "weapons": [
               {
-                "resourceName": "/pa/units/structure/bug_wall/bug_wall_acid_weapon.json",
-                "safeName": "bug_wall_acid_weapon",
-                "name": "bug_wall_acid_weapon",
+                "resourceName": "/pa/units/structure/bug_turret_acid/turret_acid_dot_weapon.json",
+                "safeName": "turret_acid_dot_weapon",
+                "name": "turret_acid_dot_weapon",
                 "count": 1,
                 "rateOfFire": 6,
                 "damage": 5,
@@ -7550,17 +7550,17 @@
                 "projectilesPerFire": 1,
                 "maxRange": 20,
                 "splashRadius": 12,
-                "fullDamageRadius": 6,
+                "fullDamageRadius": 4,
                 "targetLayers": [
                   "LandHorizontal",
                   "WaterSurface"
                 ],
                 "ammoDetails": {
-                  "resourceName": "/pa/units/structure/bug_wall/bug_wall_acid_ammo.json",
-                  "safeName": "bug_wall_acid_ammo",
-                  "name": "bug_wall_acid_ammo",
+                  "resourceName": "/pa/units/structure/bug_turret_acid/turret_acid_dot_ammo.json",
+                  "safeName": "turret_acid_dot_ammo",
+                  "name": "turret_acid_dot_ammo",
                   "damage": 5,
-                  "fullDamageRadius": 6,
+                  "fullDamageRadius": 4,
                   "splashRadius": 12
                 }
               }
@@ -7709,7 +7709,7 @@
       }
     },
     {
-      "identifier": "turret_acid_dot",
+      "identifier": "bug_wall_acid",
       "displayName": "bug bomber dot",
       "unitTypes": [
         "Structure",
@@ -7723,13 +7723,13 @@
       "source": "pa",
       "files": [
         {
-          "path": "pa/units/structure/bug_turret_acid/turret_acid_dot.json",
+          "path": "pa/units/structure/bug_wall/bug_wall_acid.json",
           "source": "com.pa.ferretmaster.bugs"
         }
       ],
       "unit": {
-        "id": "turret_acid_dot",
-        "resourceName": "/pa/units/structure/bug_turret_acid/turret_acid_dot.json",
+        "id": "bug_wall_acid",
+        "resourceName": "/pa/units/structure/bug_wall/bug_wall_acid.json",
         "displayName": "bug bomber dot",
         "description": "Land Mine - damage over time unit",
         "tier": 1,
@@ -7745,14 +7745,14 @@
         "accessible": false,
         "specs": {
           "combat": {
-            "health": 100,
+            "health": 140,
             "dps": 30,
             "salvoDamage": 5,
             "weapons": [
               {
-                "resourceName": "/pa/units/structure/bug_turret_acid/turret_acid_dot_weapon.json",
-                "safeName": "turret_acid_dot_weapon",
-                "name": "turret_acid_dot_weapon",
+                "resourceName": "/pa/units/structure/bug_wall/bug_wall_acid_weapon.json",
+                "safeName": "bug_wall_acid_weapon",
+                "name": "bug_wall_acid_weapon",
                 "count": 1,
                 "rateOfFire": 6,
                 "damage": 5,
@@ -7760,17 +7760,17 @@
                 "projectilesPerFire": 1,
                 "maxRange": 20,
                 "splashRadius": 12,
-                "fullDamageRadius": 4,
+                "fullDamageRadius": 6,
                 "targetLayers": [
                   "LandHorizontal",
                   "WaterSurface"
                 ],
                 "ammoDetails": {
-                  "resourceName": "/pa/units/structure/bug_turret_acid/turret_acid_dot_ammo.json",
-                  "safeName": "turret_acid_dot_ammo",
-                  "name": "turret_acid_dot_ammo",
+                  "resourceName": "/pa/units/structure/bug_wall/bug_wall_acid_ammo.json",
+                  "safeName": "bug_wall_acid_ammo",
+                  "name": "bug_wall_acid_ammo",
                   "damage": 5,
-                  "fullDamageRadius": 4,
+                  "fullDamageRadius": 6,
                   "splashRadius": 12
                 }
               }
@@ -7842,6 +7842,29 @@
             "salvoDamage": 50,
             "weapons": [
               {
+                "resourceName": "/pa/units/land/bug_boomer_big/bug_boomer_big_dot_weapon.json",
+                "safeName": "bug_boomer_big_dot_weapon",
+                "name": "bug_boomer_big_dot_weapon",
+                "count": 1,
+                "rateOfFire": 5,
+                "damage": 50,
+                "dps": 250,
+                "projectilesPerFire": 1,
+                "maxRange": 20,
+                "splashRadius": 20,
+                "targetLayers": [
+                  "LandHorizontal",
+                  "WaterSurface"
+                ],
+                "ammoDetails": {
+                  "resourceName": "/pa/units/land/bug_boomer_big/bug_boomer_big_dot_ammo.json",
+                  "safeName": "bug_boomer_big_dot_ammo",
+                  "name": "bug_boomer_big_dot_ammo",
+                  "damage": 50,
+                  "splashRadius": 20
+                }
+              },
+              {
                 "resourceName": "/pa/units/land/bug_boomer_big/bug_boomer_big_dot_death_weapon.json",
                 "safeName": "bug_boomer_big_dot_death_weapon",
                 "name": "bug_boomer_big_dot_death_weapon",
@@ -7865,29 +7888,6 @@
                   "name": "bug_air_drone_death_ammo",
                   "fullDamageRadius": 1,
                   "splashRadius": 1
-                }
-              },
-              {
-                "resourceName": "/pa/units/land/bug_boomer_big/bug_boomer_big_dot_weapon.json",
-                "safeName": "bug_boomer_big_dot_weapon",
-                "name": "bug_boomer_big_dot_weapon",
-                "count": 1,
-                "rateOfFire": 5,
-                "damage": 50,
-                "dps": 250,
-                "projectilesPerFire": 1,
-                "maxRange": 20,
-                "splashRadius": 20,
-                "targetLayers": [
-                  "LandHorizontal",
-                  "WaterSurface"
-                ],
-                "ammoDetails": {
-                  "resourceName": "/pa/units/land/bug_boomer_big/bug_boomer_big_dot_ammo.json",
-                  "safeName": "bug_boomer_big_dot_ammo",
-                  "name": "bug_boomer_big_dot_ammo",
-                  "damage": 50,
-                  "splashRadius": 20
                 }
               }
             ]
@@ -10275,7 +10275,20 @@
                   "maxVelocity": 1500,
                   "lifetime": 5,
                   "metalCost": 5000
-                }
+                },
+                "buildableAmmo": [
+                  {
+                    "resourceName": "/pa/units/land/anti_nuke_launcher/anti_nuke_launcher_ammo.json",
+                    "safeName": "anti_nuke_launcher_ammo",
+                    "name": "anti_nuke_launcher_ammo",
+                    "damage": 1,
+                    "splashDamage": 1,
+                    "muzzleVelocity": 1500,
+                    "maxVelocity": 1500,
+                    "lifetime": 5,
+                    "metalCost": 5000
+                  }
+                ]
               }
             ]
           },
@@ -10326,70 +10339,6 @@
             "bug_bot_fab_advanced",
             "bug_air_fab_adv",
             "bug_ship_fab_adv"
-          ]
-        }
-      }
-    },
-    {
-      "identifier": "bug_chomper_unlock",
-      "displayName": "Bug Chomper Unlock",
-      "unitTypes": [
-        "Orbital",
-        "Advanced",
-        "Fighter",
-        "FactoryBuild",
-        "Custom2"
-      ],
-      "source": "pa",
-      "files": [
-        {
-          "path": "pa/units/research/unlocks/bug_chomper_unlock/bug_chomper_unlock.json",
-          "source": "com.pa.ferretmaster.bugs"
-        },
-        {
-          "path": "/pa/units/research/unlocks/bug_chomper_unlock/bug_chomper_unlock_icon_buildbar.png",
-          "source": "com.pa.ferretmaster.bugs"
-        }
-      ],
-      "unit": {
-        "id": "bug_chomper_unlock",
-        "resourceName": "/pa/units/research/unlocks/bug_chomper_unlock/bug_chomper_unlock.json",
-        "displayName": "Bug Chomper Unlock",
-        "description": "Unlocks the bug chomper, a tanky melee anti orbital unit",
-        "image": "assets/pa/units/research/unlocks/bug_chomper_unlock/bug_chomper_unlock_icon_buildbar.png",
-        "tier": 2,
-        "unitTypes": [
-          "Orbital",
-          "Advanced",
-          "Fighter",
-          "FactoryBuild",
-          "Custom2"
-        ],
-        "accessible": true,
-        "specs": {
-          "combat": {
-            "health": 1
-          },
-          "economy": {
-            "buildCost": 1000,
-            "production": {},
-            "consumption": {},
-            "storage": {},
-            "toolConsumption": {},
-            "weaponConsumption": {}
-          },
-          "mobility": {
-            "turnSpeed": 1000,
-            "acceleration": 10000,
-            "brake": 10000
-          },
-          "recon": {},
-          "storage": {},
-          "special": {}
-        },
-        "buildRelationships": {
-          "builtBy": [
-            "research_bug_chomper"
           ]
         }
       }
@@ -10485,6 +10434,70 @@
           ]
         },
         "buildableTypes": "(Custom2 \u0026 FactoryBuild \u0026 Advanced \u0026 Orbital \u0026 Fighter) - Mobile"
+      }
+    },
+    {
+      "identifier": "bug_chomper_unlock",
+      "displayName": "Bug Chomper Unlock",
+      "unitTypes": [
+        "Orbital",
+        "Advanced",
+        "Fighter",
+        "FactoryBuild",
+        "Custom2"
+      ],
+      "source": "pa",
+      "files": [
+        {
+          "path": "pa/units/research/unlocks/bug_chomper_unlock/bug_chomper_unlock.json",
+          "source": "com.pa.ferretmaster.bugs"
+        },
+        {
+          "path": "/pa/units/research/unlocks/bug_chomper_unlock/bug_chomper_unlock_icon_buildbar.png",
+          "source": "com.pa.ferretmaster.bugs"
+        }
+      ],
+      "unit": {
+        "id": "bug_chomper_unlock",
+        "resourceName": "/pa/units/research/unlocks/bug_chomper_unlock/bug_chomper_unlock.json",
+        "displayName": "Bug Chomper Unlock",
+        "description": "Unlocks the bug chomper, a tanky melee anti orbital unit",
+        "image": "assets/pa/units/research/unlocks/bug_chomper_unlock/bug_chomper_unlock_icon_buildbar.png",
+        "tier": 2,
+        "unitTypes": [
+          "Orbital",
+          "Advanced",
+          "Fighter",
+          "FactoryBuild",
+          "Custom2"
+        ],
+        "accessible": true,
+        "specs": {
+          "combat": {
+            "health": 1
+          },
+          "economy": {
+            "buildCost": 1000,
+            "production": {},
+            "consumption": {},
+            "storage": {},
+            "toolConsumption": {},
+            "weaponConsumption": {}
+          },
+          "mobility": {
+            "turnSpeed": 1000,
+            "acceleration": 10000,
+            "brake": 10000
+          },
+          "recon": {},
+          "storage": {},
+          "special": {}
+        },
+        "buildRelationships": {
+          "builtBy": [
+            "research_bug_chomper"
+          ]
+        }
       }
     },
     {
@@ -11753,6 +11766,72 @@
       }
     },
     {
+      "identifier": "bug_crusher_unlock",
+      "displayName": "Crusher Unlock",
+      "unitTypes": [
+        "Bot",
+        "Heavy",
+        "Advanced",
+        "FactoryBuild",
+        "Custom2"
+      ],
+      "source": "pa",
+      "files": [
+        {
+          "path": "pa/units/research/unlocks/bug_crusher_unlock/bug_crusher_unlock.json",
+          "source": "com.pa.ferretmaster.bugs"
+        },
+        {
+          "path": "/pa/units/research/unlocks/bug_crusher_unlock/bug_crusher_unlock_icon_buildbar.png",
+          "source": "com.pa.ferretmaster.bugs"
+        }
+      ],
+      "unit": {
+        "id": "bug_crusher_unlock",
+        "resourceName": "/pa/units/research/unlocks/bug_crusher_unlock/bug_crusher_unlock.json",
+        "displayName": "Crusher Unlock",
+        "description": "Unlocks the crusher, a durable aoe bug",
+        "image": "assets/pa/units/research/unlocks/bug_crusher_unlock/bug_crusher_unlock_icon_buildbar.png",
+        "tier": 2,
+        "unitTypes": [
+          "Bot",
+          "Heavy",
+          "Advanced",
+          "FactoryBuild",
+          "Custom2"
+        ],
+        "accessible": true,
+        "specs": {
+          "combat": {
+            "health": 1
+          },
+          "economy": {
+            "buildCost": 1500,
+            "production": {},
+            "consumption": {},
+            "storage": {},
+            "toolConsumption": {},
+            "weaponConsumption": {}
+          },
+          "mobility": {
+            "turnSpeed": 1,
+            "acceleration": 1,
+            "brake": 1
+          },
+          "recon": {
+            "visionRadius": 100
+          },
+          "storage": {},
+          "special": {}
+        },
+        "buildRelationships": {
+          "builtBy": [
+            "research_crusher"
+          ]
+        }
+      }
+    },
+    {
       "identifier": "research_crusher",
       "displayName": "Crusher Unlock",
       "unitTypes": [
@@ -11846,72 +11925,6 @@
           ]
         },
         "buildableTypes": "(Bot \u0026 Heavy \u0026 Advanced \u0026 FactoryBuild \u0026 Custom2) - Mobile"
-      }
-    },
-    {
-      "identifier": "bug_crusher_unlock",
-      "displayName": "Crusher Unlock",
-      "unitTypes": [
-        "Bot",
-        "Heavy",
-        "Advanced",
-        "FactoryBuild",
-        "Custom2"
-      ],
-      "source": "pa",
-      "files": [
-        {
-          "path": "pa/units/research/unlocks/bug_crusher_unlock/bug_crusher_unlock.json",
-          "source": "com.pa.ferretmaster.bugs"
-        },
-        {
-          "path": "/pa/units/research/unlocks/bug_crusher_unlock/bug_crusher_unlock_icon_buildbar.png",
-          "source": "com.pa.ferretmaster.bugs"
-        }
-      ],
-      "unit": {
-        "id": "bug_crusher_unlock",
-        "resourceName": "/pa/units/research/unlocks/bug_crusher_unlock/bug_crusher_unlock.json",
-        "displayName": "Crusher Unlock",
-        "description": "Unlocks the crusher, a durable aoe bug",
-        "image": "assets/pa/units/research/unlocks/bug_crusher_unlock/bug_crusher_unlock_icon_buildbar.png",
-        "tier": 2,
-        "unitTypes": [
-          "Bot",
-          "Heavy",
-          "Advanced",
-          "FactoryBuild",
-          "Custom2"
-        ],
-        "accessible": true,
-        "specs": {
-          "combat": {
-            "health": 1
-          },
-          "economy": {
-            "buildCost": 1500,
-            "production": {},
-            "consumption": {},
-            "storage": {},
-            "toolConsumption": {},
-            "weaponConsumption": {}
-          },
-          "mobility": {
-            "turnSpeed": 1,
-            "acceleration": 1,
-            "brake": 1
-          },
-          "recon": {
-            "visionRadius": 100
-          },
-          "storage": {},
-          "special": {}
-        },
-        "buildRelationships": {
-          "builtBy": [
-            "research_crusher"
-          ]
-        }
       }
     },
     {
@@ -12217,6 +12230,72 @@
       }
     },
     {
+      "identifier": "bug_hydra_unlock",
+      "displayName": "Hydra Unlock",
+      "unitTypes": [
+        "Bot",
+        "Artillery",
+        "Advanced",
+        "FactoryBuild",
+        "Custom2"
+      ],
+      "source": "pa",
+      "files": [
+        {
+          "path": "pa/units/research/unlocks/bug_hydra_unlock/bug_hydra_unlock.json",
+          "source": "com.pa.ferretmaster.bugs"
+        },
+        {
+          "path": "/pa/units/research/unlocks/bug_hydra_unlock/bug_hydra_unlock_icon_buildbar.png",
+          "source": "com.pa.ferretmaster.bugs"
+        }
+      ],
+      "unit": {
+        "id": "bug_hydra_unlock",
+        "resourceName": "/pa/units/research/unlocks/bug_hydra_unlock/bug_hydra_unlock.json",
+        "displayName": "Hydra Unlock",
+        "description": "Unlocks the hydra, a mobile artillery bug",
+        "image": "assets/pa/units/research/unlocks/bug_hydra_unlock/bug_hydra_unlock_icon_buildbar.png",
+        "tier": 2,
+        "unitTypes": [
+          "Bot",
+          "Artillery",
+          "Advanced",
+          "FactoryBuild",
+          "Custom2"
+        ],
+        "accessible": true,
+        "specs": {
+          "combat": {
+            "health": 1
+          },
+          "economy": {
+            "buildCost": 800,
+            "production": {},
+            "consumption": {},
+            "storage": {},
+            "toolConsumption": {},
+            "weaponConsumption": {}
+          },
+          "mobility": {
+            "turnSpeed": 1,
+            "acceleration": 1,
+            "brake": 1
+          },
+          "recon": {
+            "visionRadius": 100
+          },
+          "storage": {},
+          "special": {}
+        },
+        "buildRelationships": {
+          "builtBy": [
+            "research_hydra"
+          ]
+        }
+      }
+    },
+    {
       "identifier": "research_hydra",
       "displayName": "Hydra Unlock",
       "unitTypes": [
@@ -12312,72 +12391,6 @@
           ]
         },
         "buildableTypes": "(Bot \u0026 Artillery \u0026 Advanced \u0026 FactoryBuild \u0026 Custom2) - Mobile"
-      }
-    },
-    {
-      "identifier": "bug_hydra_unlock",
-      "displayName": "Hydra Unlock",
-      "unitTypes": [
-        "Bot",
-        "Artillery",
-        "Advanced",
-        "FactoryBuild",
-        "Custom2"
-      ],
-      "source": "pa",
-      "files": [
-        {
-          "path": "pa/units/research/unlocks/bug_hydra_unlock/bug_hydra_unlock.json",
-          "source": "com.pa.ferretmaster.bugs"
-        },
-        {
-          "path": "/pa/units/research/unlocks/bug_hydra_unlock/bug_hydra_unlock_icon_buildbar.png",
-          "source": "com.pa.ferretmaster.bugs"
-        }
-      ],
-      "unit": {
-        "id": "bug_hydra_unlock",
-        "resourceName": "/pa/units/research/unlocks/bug_hydra_unlock/bug_hydra_unlock.json",
-        "displayName": "Hydra Unlock",
-        "description": "Unlocks the hydra, a mobile artillery bug",
-        "image": "assets/pa/units/research/unlocks/bug_hydra_unlock/bug_hydra_unlock_icon_buildbar.png",
-        "tier": 2,
-        "unitTypes": [
-          "Bot",
-          "Artillery",
-          "Advanced",
-          "FactoryBuild",
-          "Custom2"
-        ],
-        "accessible": true,
-        "specs": {
-          "combat": {
-            "health": 1
-          },
-          "economy": {
-            "buildCost": 800,
-            "production": {},
-            "consumption": {},
-            "storage": {},
-            "toolConsumption": {},
-            "weaponConsumption": {}
-          },
-          "mobility": {
-            "turnSpeed": 1,
-            "acceleration": 1,
-            "brake": 1
-          },
-          "recon": {
-            "visionRadius": 100
-          },
-          "storage": {},
-          "special": {}
-        },
-        "buildRelationships": {
-          "builtBy": [
-            "research_hydra"
-          ]
-        }
       }
     },
     {
@@ -12941,8 +12954,6 @@
         "specs": {
           "combat": {
             "health": 18000,
-            "dps": 33000,
-            "salvoDamage": 33000,
             "weapons": [
               {
                 "resourceName": "/pa/units/land/nuke_launcher/nuke_launcher_tool_weapon.json",
@@ -12950,14 +12961,12 @@
                 "name": "nuke_launcher_tool_weapon",
                 "count": 1,
                 "rateOfFire": 1,
-                "damage": 33000,
-                "dps": 33000,
+                "damage": 0,
+                "dps": 0,
                 "projectilesPerFire": 1,
-                "muzzleVelocity": 40,
+                "muzzleVelocity": 80,
                 "maxRange": 5000,
-                "splashDamage": 33000,
-                "splashRadius": 150,
-                "fullDamageRadius": 125,
+                "splashRadius": 60,
                 "ammoSource": "factory",
                 "targetLayers": [
                   "LandHorizontal",
@@ -12972,17 +12981,27 @@
                 "yawRange": 180,
                 "pitchRange": 180,
                 "ammoDetails": {
-                  "resourceName": "/pa/units/land/nuke_launcher/nuke_launcher_ammo.json",
-                  "safeName": "nuke_launcher_ammo",
-                  "name": "nuke_launcher_ammo",
-                  "damage": 33000,
-                  "fullDamageRadius": 125,
-                  "splashDamage": 33000,
-                  "splashRadius": 150,
-                  "muzzleVelocity": 40,
-                  "maxVelocity": 75,
-                  "metalCost": 30000
-                }
+                  "resourceName": "/pa/units/structure/control_node/portal/portal_ammo.json",
+                  "safeName": "portal_ammo",
+                  "name": "portal_ammo",
+                  "splashRadius": 60,
+                  "muzzleVelocity": 80,
+                  "maxVelocity": 150,
+                  "metalCost": 5000,
+                  "spawnUnitOnDeath": "/pa/units/structure/control_node/portal/portal_charging.json"
+                },
+                "buildableAmmo": [
+                  {
+                    "resourceName": "/pa/units/structure/control_node/portal/portal_ammo.json",
+                    "safeName": "portal_ammo",
+                    "name": "portal_ammo",
+                    "splashRadius": 60,
+                    "muzzleVelocity": 80,
+                    "maxVelocity": 150,
+                    "metalCost": 5000,
+                    "spawnUnitOnDeath": "/pa/units/structure/control_node/portal/portal_charging.json"
+                  }
+                ]
               }
             ]
           },
@@ -13240,7 +13259,20 @@
                   "maxVelocity": 75,
                   "metalCost": 30000,
                   "spawnUnitOnDeath": "/pa/units/structure/bug_nuke/ammo/bug_nuke_dot.json"
-                }
+                },
+                "buildableAmmo": [
+                  {
+                    "resourceName": "/pa/units/structure/bug_nuke/ammo/bug_nuke_ammo.json",
+                    "safeName": "bug_nuke_ammo",
+                    "name": "bug_nuke_ammo",
+                    "fullDamageRadius": 125,
+                    "splashRadius": 160,
+                    "muzzleVelocity": 40,
+                    "maxVelocity": 75,
+                    "metalCost": 30000,
+                    "spawnUnitOnDeath": "/pa/units/structure/bug_nuke/ammo/bug_nuke_dot.json"
+                  }
+                ]
               }
             ]
           },


### PR DESCRIPTION
## Summary
- Update Bugs faction profile to use GitHub repositories instead of local mod IDs
- Server mod: github.com/Ferret-Master/Bug-Faction (main branch)
- Client mod: github.com/Ferret-Master/Bug-Faction-Client (main branch)

## Test plan
- [x] CLI builds successfully with updated embedded profile
- [x] Faction exports correctly (128 units, 490 assets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)