### PR TITLE
feat(web): add unit icons to dropdown selectors

### DIFF
--- a/web/src/components/BreadcrumbNav.tsx
+++ b/web/src/components/BreadcrumbNav.tsx
@@ -4,6 +4,7 @@ import Select from 'react-select'
 import { useFactionContext } from '@/contexts/FactionContext'
 import { selectStyles, type SelectOption } from './selectStyles'
 import { findBestMatchingUnit } from '@/utils/unitMatcher'
+import { UnitIcon } from './UnitIcon'
 
 const ALL_FACTIONS_VALUE = '__all__'
 
@@ -14,6 +15,7 @@ interface FactionOption extends SelectOption {
 interface UnitOptionWithFaction extends SelectOption {
   factionId: string
   factionName: string
+  imagePath?: string
 }
 
 interface BreadcrumbNavProps {
@@ -77,6 +79,7 @@ export function BreadcrumbNav({ factionId, unitId, onUnitChange, sourceUnitTypes
             label: entry.displayName,
             factionId: facId,
             factionName: factionName,
+            imagePath: entry.unit.image,
           })
         }
       }
@@ -99,6 +102,7 @@ export function BreadcrumbNav({ factionId, unitId, onUnitChange, sourceUnitTypes
       label: entry.displayName,
       factionId: selectedFactionId,
       factionName: factionName,
+      imagePath: entry.unit.image,
     })).sort((a, b) => a.label.localeCompare(b.label))
   }, [selectedFactionId, getFactionIndex, isAllFactionsSelected, factionIndexes, factions])
 
@@ -184,10 +188,16 @@ export function BreadcrumbNav({ factionId, unitId, onUnitChange, sourceUnitTypes
     }
   }
 
-  // Custom format for unit options - show faction tag when in "All factions" mode
+  // Custom format for unit options - show icon and faction tag when in "All factions" mode
   const formatUnitOption = (option: UnitOptionWithFaction) => (
-    <div className="flex items-center justify-between gap-2 w-full">
-      <span className="truncate">{option.label}</span>
+    <div className="flex items-center gap-2 w-full">
+      <UnitIcon
+        imagePath={option.imagePath}
+        alt={option.label}
+        factionId={option.factionId}
+        className="w-5 h-5 flex-shrink-0"
+      />
+      <span className="truncate flex-1">{option.label}</span>
       {isAllFactionsSelected && (
         <span className="px-1.5 py-0.5 text-xs font-medium bg-gray-600 text-gray-200 rounded flex-shrink-0">
           {option.factionName}

--- a/web/src/components/UnitIcon.tsx
+++ b/web/src/components/UnitIcon.tsx
@@ -19,8 +19,8 @@ export function UnitIcon({ imagePath, alt, className, onError, factionId: propFa
 
   if (loading) {
     return (
-      <div className={`flex items-center justify-center bg-muted ${className || ''}`}>
-        <div className="animate-pulse w-8 h-8 bg-muted-foreground/20 rounded" />
+      <div className={`flex items-center justify-center ${className || ''}`}>
+        <div className="animate-pulse w-full h-full bg-muted-foreground/20 rounded" />
       </div>
     )
   }

--- a/web/src/pages/__tests__/UnitDetail.test.tsx
+++ b/web/src/pages/__tests__/UnitDetail.test.tsx
@@ -69,10 +69,13 @@ describe('UnitDetail', () => {
     renderUnitDetail('MLA', 'tank')
 
     await waitFor(() => {
-      const icon = screen.getByAltText('Tank')
-      expect(icon).toBeInTheDocument()
+      // Multiple icons may exist (unit detail + dropdown selector), find the main one
+      const icons = screen.getAllByAltText('Tank')
+      // The main unit icon has the object-contain class
+      const mainIcon = icons.find(icon => icon.className.includes('object-contain'))
+      expect(mainIcon).toBeInTheDocument()
       // New path uses unit.image field which contains assets path
-      expect(icon).toHaveAttribute('src', '/factions/MLA/assets/pa/units/land/tank/tank_icon_buildbar.png')
+      expect(mainIcon).toHaveAttribute('src', '/factions/MLA/assets/pa/units/land/tank/tank_icon_buildbar.png')
     })
   })
 


### PR DESCRIPTION
## Summary

- Add unit buildbar icons alongside unit names in dropdown selectors to help users visually identify units
- Icons appear in the BreadcrumbNav unit selector (unit detail page) and FactionDetail search dropdown (faction page)
- Fixed UnitIcon loading state to respect className dimensions for better inline rendering

## Test plan

- [x] All 750 tests pass
- [x] TypeScript compiles without errors
- [x] ESLint passes
- [ ] Manual testing: Navigate to unit detail page, open unit selector - icons appear
- [ ] Manual testing: Navigate to faction page, open search dropdown - icons appear
- [ ] Manual testing: Test "All factions" mode - icons load from correct faction sources

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)