### PR TITLE
chore: add claude settings to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ cli/*.exe
 *.swo
 *~
 
+# Claude Code
+.claude/settings.local.json
+
 # OS
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Summary
- Add `.claude/settings.local.json` to gitignore to prevent local Claude Code settings from being tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)