### PR TITLE
feat: add Docker containerization support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+{
+  "name": "PA-Pedia Development",
+  "dockerComposeFile": ["../docker-compose.yml"],
+  "service": "dev",
+  "workspaceFolder": "/workspace",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go",
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint",
+        "bradlc.vscode-tailwindcss",
+        "ms-vscode.vscode-typescript-next",
+        "formulahendry.auto-rename-tag",
+        "streetsidesoftware.code-spell-checker"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "go.toolsManagement.autoUpdate": true,
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "[go]": {
+          "editor.defaultFormatter": "golang.go"
+        },
+        "[typescript]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "[typescriptreact]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        }
+      }
+    }
+  },
+  "postCreateCommand": "just install",
+  "remoteUser": "node",
+  "features": {}
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# Git
+.git
+.gitignore
+
+# Node modules (will be mounted as volumes)
+web/node_modules
+
+# Build outputs
+web/dist
+cli/pa-pedia
+cli/pa-pedia.exe
+factions/dist
+
+# IDE
+.idea
+.vscode
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Test outputs
+coverage
+
+# Logs
+*.log
+npm-debug.log*
+
+# Environment files with secrets
+.env
+.env.local
+.env.*.local
+
+# Claude settings (may contain API keys)
+.claude/settings.local.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# PA-Pedia Development Container
+# Includes Go, Node.js, Just, Git, and Claude Code
+
+FROM node:22-bookworm
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    wget \
+    unzip \
+    ca-certificates \
+    gnupg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Go 1.24
+ARG GO_VERSION=1.24.4
+RUN wget -q https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
+    && tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz \
+    && rm go${GO_VERSION}.linux-amd64.tar.gz
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOPATH="/go"
+ENV PATH="${GOPATH}/bin:${PATH}"
+
+# Install Just command runner
+RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+
+# Install Claude Code globally
+RUN npm install -g @anthropic-ai/claude-code
+
+# Use the existing 'node' user from the base image (UID/GID 1000)
+# Set up Go directories with correct ownership
+RUN mkdir -p /go/pkg /go/bin \
+    && chown -R node:node /go
+
+# Set up working directory
+WORKDIR /workspace
+
+# Switch to non-root user
+USER node
+
+# Configure Git for the node user
+RUN git config --global init.defaultBranch main \
+    && git config --global core.autocrlf input
+
+# Default command
+CMD ["bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: pa-pedia-dev
+    volumes:
+      # Mount the project directory
+      - .:/workspace
+      # Persist Go module cache
+      - go-mod-cache:/go/pkg/mod
+      # Persist npm cache
+      - npm-cache:/home/node/.npm
+      # Persist node_modules separately to avoid cross-platform issues
+      - web-node-modules:/workspace/web/node_modules
+    working_dir: /workspace
+    # Keep container running
+    stdin_open: true
+    tty: true
+    # Environment variables
+    environment:
+      - GOPATH=/go
+      - NODE_ENV=development
+    # Expose ports for development
+    ports:
+      - "5173:5173"  # Vite dev server
+      - "4173:4173"  # Vite preview
+    # Run as the node user (from base image, UID/GID 1000)
+    user: node
+
+volumes:
+  go-mod-cache:
+  npm-cache:
+  web-node-modules:

--- a/justfile
+++ b/justfile
@@ -149,10 +149,17 @@ build: cli-build web-build
 generate-sitemap:
     npm run generate-sitemap
 
-# Clean build artifacts
+# Clean build artifacts (Windows)
+[windows]
 [working-directory: 'cli']
 clean:
     -Remove-Item -Force pa-pedia, pa-pedia.exe, coverage.out -ErrorAction SilentlyContinue
+
+# Clean build artifacts (Unix/Container)
+[unix]
+[working-directory: 'cli']
+clean:
+    rm -f pa-pedia pa-pedia.exe coverage.out
 
 # ============================================================================
 # Shortcuts / Aliases
@@ -161,10 +168,55 @@ clean:
 # Alias: Run web dev server
 dev: web-dev
 
-# Run web dev server with live production faction data
+# Run web dev server with live production faction data (Windows)
+[windows]
 [working-directory: 'web']
 dev-live:
     $env:VITE_USE_LIVE_DATA='true'; npm run dev
 
+# Run web dev server with live production faction data (Unix/Container)
+[unix]
+[working-directory: 'web']
+dev-live:
+    VITE_USE_LIVE_DATA=true npm run dev
+
 # Alias: Build CLI
 build-cli: cli-build
+
+# ============================================================================
+# Docker / Container Commands
+# ============================================================================
+
+# Build the development container
+docker-build:
+    docker compose build
+
+# Start the development container
+docker-up:
+    docker compose up -d
+
+# Stop the development container
+docker-down:
+    docker compose down
+
+# Open a shell in the running container
+docker-shell:
+    docker compose exec dev bash
+
+# Run a command in the container (e.g., just docker-run "just test")
+docker-run cmd:
+    docker compose exec dev {{cmd}}
+
+# View container logs
+docker-logs:
+    docker compose logs -f dev
+
+# Full container rebuild (no cache)
+docker-rebuild:
+    docker compose build --no-cache
+
+# Start fresh: stop, remove volumes, rebuild
+docker-reset:
+    docker compose down -v
+    docker compose build
+    docker compose up -d

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -50,6 +50,8 @@ export default defineConfig({
     },
   },
   server: {
+    // Bind to all addresses (required for Docker container access)
+    host: true,
     fs: {
       // Allow serving files from the factions folder at repo root
       allow: ['..'],


### PR DESCRIPTION
## Summary
- Add Dockerfile with Go 1.24, Node.js 22, Just, Git, and Claude Code pre-installed
- Add docker-compose.yml with volume mounts for dependency caching
- Add VS Code Dev Container configuration with recommended extensions
- Update justfile with cross-platform commands and Docker helpers (`just docker-build`, `just docker-up`, etc.)
- Configure Vite to bind to all addresses for container network access

## Test plan
- [ ] Run `just docker-build` to build the container
- [ ] Run `just docker-up` followed by `just docker-shell` to enter the container
- [ ] Run `just install` inside container to install dependencies
- [ ] Run `just dev` and verify web server is accessible at localhost:5173
- [ ] Run `just test` to verify both CLI and web tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)