### PR TITLE
fix(cli): require version for faction exports instead of defaulting to 1.0.0

### DIFF
--- a/cli/profiles/embedded/legion.json
+++ b/cli/profiles/embedded/legion.json
@@ -1,6 +1,8 @@
 {
   "displayName": "Legion",
   "factionUnitType": "Custom1",
+  "version": "1.32.1",
+  "build": "124615",
   "mods": [
     "github.com/Legion-Expansion/Legion-Expansion/tree/develop/src/server",
     "github.com/Legion-Expansion/Legion-Expansion/tree/develop/src/client"

--- a/factions/Legion/metadata.json
+++ b/factions/Legion/metadata.json
@@ -1,8 +1,9 @@
 {
   "identifier": "legion",
   "displayName": "Legion",
-  "version": "1.0.0",
+  "version": "1.32.1",
   "author": "nicb1, Crembels, KillerKiwiJuice, mgmetal13, zx0, Luther, Alpha2546, PRoeleert, wondible, mikeyh, Quitch, Stuart98, dom314, CptConundrum, Elodea, AndreasG, Clopse, Graushwein, N30N, Qzipco, WPMarshall, xankar",
+  "build": "124615",
   "type": "mod",
   "mods": [
     "github.com/Legion-Expansion/Legion-Expansion/tree/develop/src/server",


### PR DESCRIPTION
## Summary
- Add `--version` flag for manual version override when auto-detection fails
- Return error when no version is found instead of silently defaulting to `1.0.0`
- Fix Legion profile and faction data to use correct version `1.32.1`

## Background
Legion's GitHub source files don't include the version field in modinfo.json (it's populated during their build process). This caused exports to incorrectly use the default `1.0.0` version.

The incorrect `legion-1.0.0-pedia20260115214519.zip` has been deleted from the GitHub Release. Only `legion-1.32.1-124615-pedia20260110012833.zip` remains.

## Test plan
- [ ] Run `just cli-build` - should compile successfully
- [ ] Run `just cli-test` - all tests should pass
- [ ] Test export without version: should error with helpful message
- [ ] Test export with `--version` flag: should use provided version
- [ ] Verify Legion profile has version `1.32.1` and build `124615`

🤖 Generated with [Claude Code](https://claude.com/claude-code)