### PR TITLE
ci: remove redundant CI Success gate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,20 +98,3 @@ jobs:
           path: web/playwright-report/
           retention-days: 7
 
-  ci-success:
-    name: CI Success
-    if: always()
-    needs: [cli, web, e2e]
-    runs-on: ubuntu-latest
-    timeout-minutes: 1
-    steps:
-      - name: Check all jobs passed
-        run: |
-          if [[ "${{ needs.cli.result }}" != "success" || "${{ needs.web.result }}" != "success" || "${{ needs.e2e.result }}" != "success" ]]; then
-            echo "One or more CI jobs failed:"
-            echo "  cli: ${{ needs.cli.result }}"
-            echo "  web: ${{ needs.web.result }}"
-            echo "  e2e: ${{ needs.e2e.result }}"
-            exit 1
-          fi
-          echo "All CI jobs passed!"


### PR DESCRIPTION
## Summary
- Remove the `ci-success` gate job from CI workflow
- Individual CI jobs (CLI, Web, E2E) should be configured as required status checks directly in GitHub branch protection settings instead

## Follow-up
After merging, update branch protection rules:
1. Remove `CI / CI Success` if listed
2. Add `CI / E2E (Playwright)` as a required status check

🤖 Generated with [Claude Code](https://claude.com/claude-code)