### PR TITLE
fix: deterministic unit ordering to prevent spurious update PRs

### DIFF
--- a/cli/pkg/parser/database.go
+++ b/cli/pkg/parser/database.go
@@ -493,12 +493,19 @@ func (db *Database) GetUnitsArray() []models.Unit {
 		units = append(units, *unit)
 	}
 
-	// Sort by tier, then by display name
+	// Sort by tier, then by display name, then by ID for deterministic output.
+	// The ID tiebreaker is needed because sort.Slice is not stable and the input
+	// comes from map iteration (random order). Without it, units sharing the same
+	// tier and display name (e.g. bug_boomer/bug_boomer_r) swap between runs,
+	// causing spurious diffs in the update-factions workflow.
 	sort.Slice(units, func(i, j int) bool {
 		if units[i].Tier != units[j].Tier {
 			return units[i].Tier < units[j].Tier
 		}
-		return units[i].DisplayName < units[j].DisplayName
+		if units[i].DisplayName != units[j].DisplayName {
+			return units[i].DisplayName < units[j].DisplayName
+		}
+		return units[i].ID < units[j].ID
 	})
 
 	return units


### PR DESCRIPTION
## Summary
- Units sharing the same tier and display name (e.g. `bug_boomer`/`bug_boomer_r` both "Boomer" T1, `basic_missile_defence`/`basic_missile_defence_7` both "Spear" T1) swapped positions between CLI runs
- Root cause: `sort.Slice` is unstable + input comes from Go map iteration (random order)
- Fix: add unique unit ID as third sort key in `GetUnitsArray()`
- This caused the update-factions workflow to create spurious PRs #327 and #328 (which should be closed)

## Test plan
- [x] `just cli-test` passes
- [ ] After merge, close spurious PRs #327 and #328
- [ ] Next nightly run should produce no PRs (no real upstream changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)