### PR TITLE
fix: show sustained DPS for ammo-limited units in table view

### DIFF
--- a/web/src/components/stats/OverviewSection.tsx
+++ b/web/src/components/stats/OverviewSection.tsx
@@ -5,6 +5,7 @@ import { BlueprintLink } from '../BlueprintLink';
 import { ComparisonValue } from '../ComparisonValue';
 import { SpawnUnitLink } from './SpawnUnitLink';
 import { isDifferent } from '@/utils/comparison';
+import { getEffectiveUnitDps } from '@/utils/effectiveDps';
 import { calculateDpsByLayer, getSortedLayers, formatLayerName } from '@/utils/targetLayers';
 import type { DpsByLayer } from '@/utils/targetLayers';
 import type { Unit } from '@/types/faction';
@@ -16,21 +17,12 @@ import type { AggregatedGroupStats } from '@/types/group';
  * This ensures consistent behavior with group mode calculation.
  */
 function calculateUnitSustainedDps(unit: Unit | undefined): number | undefined {
-  if (!unit?.specs.combat.weapons) return undefined;
-
-  // Check if any weapon has sustained DPS that differs from burst
-  const hasSustainedWeapons = unit.specs.combat.weapons.some(
-    w => !w.selfDestruct && !w.deathExplosion &&
-         w.sustainedDps !== undefined && w.sustainedDps !== w.dps
-  );
-
-  if (!hasSustainedWeapons) return undefined;
-
-  // Sum sustained DPS: use sustainedDps if available, otherwise use dps
-  return unit.specs.combat.weapons.reduce((sum, w) => {
-    if (w.selfDestruct || w.deathExplosion) return sum;
-    return sum + (w.sustainedDps ?? w.dps ?? 0) * (w.count ?? 1);
-  }, 0);
+  if (!unit) return undefined;
+  const effective = getEffectiveUnitDps(unit);
+  const burst = unit.specs.combat.dps;
+  // Only return if sustained differs from burst
+  if (effective === burst) return undefined;
+  return effective;
 }
 
 interface OverviewSectionProps {

--- a/web/src/pages/UnitDetail.tsx
+++ b/web/src/pages/UnitDetail.tsx
@@ -23,6 +23,7 @@ import { EconomySection } from '@/components/stats/EconomySection'
 import { StorageSection } from '@/components/stats/StorageSection'
 import { matchWeaponsByTargetLayers } from '@/utils/weaponMatching'
 import { aggregateGroupStats, matchAggregatedWeapons } from '@/utils/groupAggregation'
+import { getEffectiveUnitDps } from '@/utils/effectiveDps'
 import {
   GroupModeToggle,
   GroupWeaponCard,
@@ -458,7 +459,8 @@ export function UnitDetail() {
   const anyComparisonHasDeathExplosion = comparisonUnits.some(u => u?.specs.combat.weapons?.some(w => w.deathExplosion))
 
   // SEO data for unit page
-  const unitDescription = `${unit.displayName} - ${unit.unitTypes.join(', ')} unit in Planetary Annihilation: Titans. Health: ${specs.combat.health}${specs.economy.buildCost ? `, Build Cost: ${specs.economy.buildCost}` : ''}${specs.combat.dps ? `, DPS: ${specs.combat.dps.toFixed(1)}` : ''}.`
+  const effectiveDps = getEffectiveUnitDps(unit)
+  const unitDescription = `${unit.displayName} - ${unit.unitTypes.join(', ')} unit in Planetary Annihilation: Titans. Health: ${specs.combat.health}${specs.economy.buildCost ? `, Build Cost: ${specs.economy.buildCost}` : ''}${effectiveDps ? `, DPS: ${effectiveDps.toFixed(1)}` : ''}.`
   const seoPath = `/faction/${factionId}/unit/${unitId}`
 
   return (

--- a/web/src/utils/__tests__/effectiveDps.test.ts
+++ b/web/src/utils/__tests__/effectiveDps.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest'
+import { getEffectiveUnitDps } from '@/utils/effectiveDps'
+import type { Unit } from '@/types/faction'
+
+/** Minimal unit helper - only fills fields relevant to DPS calculation */
+function makeUnit(overrides: Partial<Unit> = {}): Unit {
+  return {
+    id: 'test',
+    resourceName: '/pa/units/test/test.json',
+    displayName: 'Test Unit',
+    tier: 1,
+    unitTypes: [],
+    accessible: true,
+    specs: {
+      combat: { health: 100 },
+      economy: { buildCost: 100 },
+    },
+    buildRelationships: {},
+    ...overrides,
+  } as Unit
+}
+
+describe('getEffectiveUnitDps', () => {
+  it('returns burst DPS when no weapons', () => {
+    const unit = makeUnit({
+      specs: {
+        combat: { health: 100, dps: 50 },
+        economy: { buildCost: 100 },
+      },
+    } as Partial<Unit>)
+    expect(getEffectiveUnitDps(unit)).toBe(50)
+  })
+
+  it('returns burst DPS when weapons have no sustained DPS', () => {
+    const unit = makeUnit({
+      specs: {
+        combat: {
+          health: 100,
+          dps: 200,
+          weapons: [
+            { safeName: 'gun', resourceName: '/gun.json', count: 2, rateOfFire: 10, damage: 10, dps: 100 },
+          ],
+        },
+        economy: { buildCost: 100 },
+      },
+    } as Partial<Unit>)
+    expect(getEffectiveUnitDps(unit)).toBe(200)
+  })
+
+  it('returns sustained DPS when weapons are ammo-limited (Cub scenario)', () => {
+    const unit = makeUnit({
+      specs: {
+        combat: {
+          health: 110,
+          dps: 200,
+          weapons: [
+            {
+              safeName: 'can_tool_weapon',
+              resourceName: '/pa/units/land/can/can_tool_weapon.json',
+              count: 2,
+              rateOfFire: 10,
+              damage: 10,
+              dps: 100,
+              sustainedDps: 13.33,
+            },
+          ],
+        },
+        economy: { buildCost: 70 },
+      },
+    } as Partial<Unit>)
+    expect(getEffectiveUnitDps(unit)).toBeCloseTo(26.66, 1)
+  })
+
+  it('mixes sustained and non-sustained weapons correctly', () => {
+    const unit = makeUnit({
+      specs: {
+        combat: {
+          health: 500,
+          dps: 150,
+          weapons: [
+            { safeName: 'gun', resourceName: '/gun.json', count: 1, rateOfFire: 5, damage: 10, dps: 50 },
+            { safeName: 'cannon', resourceName: '/cannon.json', count: 1, rateOfFire: 10, damage: 10, dps: 100, sustainedDps: 20 },
+          ],
+        },
+        economy: { buildCost: 200 },
+      },
+    } as Partial<Unit>)
+    // gun: no sustained -> uses dps=50, cannon: sustained=20
+    expect(getEffectiveUnitDps(unit)).toBe(70)
+  })
+
+  it('excludes death explosion weapons', () => {
+    const unit = makeUnit({
+      specs: {
+        combat: {
+          health: 100,
+          dps: 200,
+          weapons: [
+            { safeName: 'gun', resourceName: '/gun.json', count: 1, rateOfFire: 10, damage: 10, dps: 100, sustainedDps: 20 },
+            { safeName: 'boom', resourceName: '/boom.json', count: 1, rateOfFire: 1, damage: 500, dps: 500, deathExplosion: true },
+          ],
+        },
+        economy: { buildCost: 100 },
+      },
+    } as Partial<Unit>)
+    expect(getEffectiveUnitDps(unit)).toBe(20)
+  })
+
+  it('excludes self-destruct weapons', () => {
+    const unit = makeUnit({
+      specs: {
+        combat: {
+          health: 100,
+          dps: 200,
+          weapons: [
+            { safeName: 'gun', resourceName: '/gun.json', count: 1, rateOfFire: 10, damage: 10, dps: 100, sustainedDps: 30 },
+            { safeName: 'nuke', resourceName: '/nuke.json', count: 1, rateOfFire: 1, damage: 1000, dps: 1000, selfDestruct: true },
+          ],
+        },
+        economy: { buildCost: 100 },
+      },
+    } as Partial<Unit>)
+    expect(getEffectiveUnitDps(unit)).toBe(30)
+  })
+
+  it('returns undefined when no combat DPS', () => {
+    const unit = makeUnit({
+      specs: {
+        combat: { health: 100 },
+        economy: { buildCost: 100 },
+      },
+    } as Partial<Unit>)
+    expect(getEffectiveUnitDps(unit)).toBeUndefined()
+  })
+
+  it('returns burst DPS when sustained equals burst', () => {
+    const unit = makeUnit({
+      specs: {
+        combat: {
+          health: 100,
+          dps: 100,
+          weapons: [
+            { safeName: 'gun', resourceName: '/gun.json', count: 1, rateOfFire: 10, damage: 10, dps: 100, sustainedDps: 100 },
+          ],
+        },
+        economy: { buildCost: 100 },
+      },
+    } as Partial<Unit>)
+    // sustainedDps === dps, so no sustained weapons detected
+    expect(getEffectiveUnitDps(unit)).toBe(100)
+  })
+})

--- a/web/src/utils/effectiveDps.ts
+++ b/web/src/utils/effectiveDps.ts
@@ -1,0 +1,29 @@
+import type { Unit } from '@/types/faction'
+
+/**
+ * Calculate the effective DPS for a unit, accounting for ammo-limited weapons.
+ *
+ * When any weapon has a sustained DPS (ammo recovery limits fire rate),
+ * returns the total sustained DPS across all weapons. Otherwise returns
+ * the burst DPS from combat.dps.
+ *
+ * This ensures consistent DPS display across table view, detail view,
+ * and SEO metadata.
+ */
+export function getEffectiveUnitDps(unit: Unit): number | undefined {
+  const burstDps = unit.specs.combat.dps
+  const weapons = unit.specs.combat.weapons
+  if (!weapons?.length) return burstDps
+
+  const hasSustainedWeapons = weapons.some(
+    w => !w.selfDestruct && !w.deathExplosion &&
+         w.sustainedDps !== undefined && w.sustainedDps !== w.dps
+  )
+
+  if (!hasSustainedWeapons) return burstDps
+
+  return weapons.reduce((sum, w) => {
+    if (w.selfDestruct || w.deathExplosion) return sum
+    return sum + (w.sustainedDps ?? w.dps ?? 0) * (w.count ?? 1)
+  }, 0)
+}

--- a/web/src/utils/tableColumns.ts
+++ b/web/src/utils/tableColumns.ts
@@ -1,4 +1,5 @@
 import type { UnitIndexEntry } from '@/types/faction'
+import { getEffectiveUnitDps } from '@/utils/effectiveDps'
 
 // All available column IDs
 export type ColumnId =
@@ -164,7 +165,7 @@ export const COLUMN_DEFS: Record<ColumnId, ColumnDef> = {
     id: 'dps',
     label: 'DPS',
     align: 'right',
-    getValue: (entry) => entry.unit.specs.combat.dps,
+    getValue: (entry) => getEffectiveUnitDps(entry.unit),
     format: formatDecimal,
     responsive: 'hidden sm:table-cell',
   },


### PR DESCRIPTION
## Summary
- **Bug**: Table view showed burst DPS (200) for the Cub instead of sustained DPS (26.7). The unit detail page was already correct.
- **Root cause**: The table DPS column read `combat.dps` (burst) directly, while the unit detail page recalculated from individual weapon sustained DPS values.
- **Fix**: Extract `getEffectiveUnitDps()` utility that returns sustained DPS when weapons are ammo-limited, burst DPS otherwise. Used in table column, OverviewSection, and SEO meta description.

## Files changed
- `web/src/utils/effectiveDps.ts` — new shared utility
- `web/src/utils/__tests__/effectiveDps.test.ts` — 8 test cases
- `web/src/utils/tableColumns.ts` — table DPS column uses effective DPS
- `web/src/components/stats/OverviewSection.tsx` — refactored to use shared utility
- `web/src/pages/UnitDetail.tsx` — SEO description uses effective DPS

## Test plan
- [x] All 831 existing tests pass
- [x] 8 new unit tests for `getEffectiveUnitDps` (including Cub scenario)
- [x] Lint clean
- [x] Verified in browser: Cub shows DPS 26.7 in table (was 200)
- [x] Verified unit detail page still shows both sustained (26.7) and burst (200) DPS correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)