### PR TITLE
fix(scripts): order manifest versions by version number, not build timestamp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,10 +334,10 @@ Triggers on:
 ```
 
 **Version History**:
-- `latest`: Points to the most recent version (highest timestamp)
-- `versions`: Array of all available versions (newest first)
+- `latest`: Points to the highest **version number** (not build timestamp — so out-of-order publishing can't make an older version look newest). See `scripts/version-compare.ts`.
+- `versions`: Array of all available versions, ordered by version number (newest first); the UI treats `versions[0]` as latest
 - Historical versions are preserved when a faction's version number changes
-- Same-version rebuilds (different timestamp, same version) replace older timestamps
+- Same-version rebuilds (different timestamp, same version) replace older timestamps (timestamp is the tie-breaker only within an identical version)
 
 **Version Tracking**:
 - `version`: Extracted from faction `metadata.json` (CLI-generated)

--- a/scripts/generate-manifest.ts
+++ b/scripts/generate-manifest.ts
@@ -14,6 +14,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { execSync } from 'node:child_process'
 import JSZip from 'jszip'
+import { byVersionDesc } from './version-compare'
 
 const FACTIONS_DIR = path.join(import.meta.dirname, '..', 'factions')
 const OUTPUT_DIR = path.join(FACTIONS_DIR, 'dist')
@@ -192,12 +193,11 @@ async function main() {
     string,
     {
       versions: Array<{ zip: (typeof zipAssets)[0]; metadata: FactionMetadata | null }>
-      latestTimestamp: number
     }
   >()
 
   for (const [key, zip] of versionMap) {
-    const { factionId, version, timestamp } = zip.parsed!
+    const { factionId, version } = zip.parsed!
     const ghDownloadUrl = zip.asset.url
 
     console.log(`Processing ${factionId} v${version}...`)
@@ -208,24 +208,26 @@ async function main() {
     // Get or create faction entry
     let factionData = factionVersions.get(factionId)
     if (!factionData) {
-      factionData = { versions: [], latestTimestamp: 0 }
+      factionData = { versions: [] }
       factionVersions.set(factionId, factionData)
     }
 
     factionData.versions.push({ zip, metadata })
-
-    // Track latest timestamp for determining the "latest" version
-    if (timestamp > factionData.latestTimestamp) {
-      factionData.latestTimestamp = timestamp
-    }
   }
 
   // Step 3: Build faction entries with version arrays
   const factionEntries: FactionEntry[] = []
 
   for (const [factionId, factionData] of factionVersions) {
-    // Sort versions by timestamp (newest first)
-    factionData.versions.sort((a, b) => b.zip.parsed!.timestamp - a.zip.parsed!.timestamp)
+    // Sort by version number (newest first), NOT by build timestamp. Timestamp
+    // ordering breaks when versions are published out of order (e.g. an older
+    // version's PR merged after a newer one); version ordering is stable.
+    factionData.versions.sort((a, b) =>
+      byVersionDesc(
+        { version: a.zip.parsed!.version, timestamp: a.zip.parsed!.timestamp },
+        { version: b.zip.parsed!.version, timestamp: b.zip.parsed!.timestamp }
+      )
+    )
 
     // Build version entries
     const versions: VersionEntry[] = factionData.versions.map(({ zip, metadata }) => ({
@@ -237,7 +239,7 @@ async function main() {
       build: metadata?.build,
     }))
 
-    // Latest is the first one (highest timestamp)
+    // Latest is the first one (highest version number)
     const latestVersion = factionData.versions[0]
     const latestMetadata = latestVersion.metadata
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,6 +4,7 @@
   "description": "Build scripts for PA-Pedia faction data management",
   "type": "module",
   "scripts": {
+    "test": "node --import tsx --test version-compare.test.ts",
     "build:zips": "tsx build-faction-zips.ts",
     "upload:releases": "tsx upload-to-releases.ts",
     "generate:manifest": "tsx generate-manifest.ts",

--- a/scripts/version-compare.test.ts
+++ b/scripts/version-compare.test.ts
@@ -1,0 +1,74 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { compareVersions, byVersionDesc } from './version-compare'
+
+test('numeric segment compare beats string compare (0.7.10 > 0.7.8)', () => {
+  assert.ok(compareVersions('0.7.10', '0.7.8') > 0)
+  assert.ok(compareVersions('0.7.8', '0.7.10') < 0)
+})
+
+test('compares segment-by-segment left to right', () => {
+  assert.ok(compareVersions('0.7.7.0', '0.7.8') < 0) // 7 < 8 at 3rd segment
+  assert.ok(compareVersions('0.7.20', '0.7.10') > 0)
+  assert.ok(compareVersions('0.8', '0.7.99') > 0)
+})
+
+test('missing trailing segments treated as 0', () => {
+  assert.equal(compareVersions('0.7.6', '0.7.6.0'), 0)
+  assert.ok(compareVersions('0.7', '0.7.1') < 0)
+})
+
+test('equal versions return 0', () => {
+  assert.equal(compareVersions('0.7.20', '0.7.20'), 0)
+  assert.equal(compareVersions('124651', '124651'), 0)
+})
+
+test('handles each factions versioning scheme', () => {
+  assert.ok(compareVersions('1.38', '1.37') > 0) // Bugs
+  assert.ok(compareVersions('0.15.0', '0.14.5') > 0) // Second-Wave
+  assert.ok(compareVersions('124651', '124632') > 0) // MLA build numbers
+  assert.ok(compareVersions('1.32.1', '1.32.0') > 0) // Legion
+})
+
+test('byVersionDesc orders a full Exiles version list newest-first', () => {
+  const input = [
+    { version: '0.7.1', timestamp: 1 },
+    { version: '0.7.20', timestamp: 2 },
+    { version: '0.7.7.0', timestamp: 3 },
+    { version: '0.7.10', timestamp: 4 },
+    { version: '0.7.6.0', timestamp: 5 },
+    { version: '0.7.8', timestamp: 6 },
+    { version: '0.7.3.4', timestamp: 7 },
+    { version: '0.7.5.0', timestamp: 8 },
+  ]
+  const ordered = [...input].sort(byVersionDesc).map((v) => v.version)
+  assert.deepEqual(ordered, [
+    '0.7.20',
+    '0.7.10',
+    '0.7.8',
+    '0.7.7.0',
+    '0.7.6.0',
+    '0.7.5.0',
+    '0.7.3.4',
+    '0.7.1',
+  ])
+})
+
+test('out-of-order timestamps do not change version ordering', () => {
+  // v0.7.7.0 published (timestamp) AFTER v0.7.20 — version order must still win
+  const input = [
+    { version: '0.7.20', timestamp: 100 },
+    { version: '0.7.7.0', timestamp: 999 },
+  ]
+  const ordered = [...input].sort(byVersionDesc).map((v) => v.version)
+  assert.deepEqual(ordered, ['0.7.20', '0.7.7.0'])
+})
+
+test('timestamp only breaks ties for identical versions', () => {
+  const input = [
+    { version: '0.7.20', timestamp: 10 },
+    { version: '0.7.20', timestamp: 20 },
+  ]
+  const ordered = [...input].sort(byVersionDesc).map((v) => v.timestamp)
+  assert.deepEqual(ordered, [20, 10])
+})

--- a/scripts/version-compare.ts
+++ b/scripts/version-compare.ts
@@ -1,0 +1,54 @@
+/**
+ * Version comparison for faction manifest ordering.
+ *
+ * Faction versions come from upstream mod `modinfo.json` and are dotted-numeric
+ * strings of varying length (e.g. "0.7.20", "0.7.7.0", "1.32.1", "124651").
+ *
+ * The manifest must order versions and pick "latest" by *version number*, NOT by
+ * build timestamp. Timestamp ordering breaks when versions are built/merged out
+ * of order (e.g. merging v0.7.7.0's PR after v0.7.20 would otherwise make the
+ * older version look newest). Version-number ordering is stable regardless of
+ * the order in which versions happen to be published.
+ *
+ * Comparison is segment-by-segment, numeric where both segments parse as numbers
+ * (so 0.7.10 > 0.7.8, which a string compare gets wrong). Missing trailing
+ * segments are treated as 0, so "0.7.6" === "0.7.6.0". Non-numeric segments fall
+ * back to a numeric-aware locale compare.
+ */
+
+/**
+ * Compare two version strings.
+ * @returns negative if a < b, positive if a > b, 0 if equal
+ */
+export function compareVersions(a: string, b: string): number {
+  const pa = a.split('.')
+  const pb = b.split('.')
+  const len = Math.max(pa.length, pb.length)
+
+  for (let i = 0; i < len; i++) {
+    const sa = pa[i] ?? '0'
+    const sb = pb[i] ?? '0'
+    const na = Number(sa)
+    const nb = Number(sb)
+
+    if (!Number.isNaN(na) && !Number.isNaN(nb)) {
+      if (na !== nb) return na - nb
+    } else {
+      const c = sa.localeCompare(sb, undefined, { numeric: true })
+      if (c !== 0) return c
+    }
+  }
+
+  return 0
+}
+
+/**
+ * Sort comparator for ordering versions newest-first (descending by version),
+ * with build timestamp as a stable tie-breaker for identical version strings.
+ */
+export function byVersionDesc(
+  a: { version: string; timestamp: number },
+  b: { version: string; timestamp: number }
+): number {
+  return compareVersions(b.version, a.version) || b.timestamp - a.timestamp
+}


### PR DESCRIPTION
## Summary

Fixes the **order-of-merge** problem: the manifest chose "latest" and ordered the version dropdown by **build timestamp** (`generate-manifest.ts`). If versions are published out of order — e.g. an older version's PR merged *after* a newer one — the older version gets a newer timestamp and surfaces as "latest". `VersionSelector.tsx:118-121` treats `versions[0]` as latest, so this was user-visible.

Now ordering is by **version number** (per-faction, dotted-numeric, segment-by-segment so `0.7.10 > 0.7.8` — which a string/timestamp compare gets wrong), with timestamp as a tie-breaker only within an identical version. Stable regardless of publish/merge order.

## Changes
- New pure module `scripts/version-compare.ts` (`compareVersions`, `byVersionDesc`).
- `generate-manifest.ts` sorts with `byVersionDesc`; removed now-dead `latestTimestamp` tracking.
- **8 unit tests** (`node:test`, run via `npm test` in `scripts/`), including the out-of-order-timestamp regression and each faction's versioning scheme.
- Updated `CLAUDE.md` manifest docs.

## Notes
- No live data change now — the current manifest is already correctly ordered (recovery backfill used ascending timestamps). This makes it *robust* going forward; the new logic applies on the next `faction-data` run.
- `npm test` is local-only for now (no scripts test job in CI). Wiring it into CI can be a small follow-up if wanted.

## Verification
`cd scripts && npm test` → 8/8 pass. `npx tsc --noEmit` → clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)