### PR TITLE
feat(ci): auto-merge faction update PRs when checks pass

### DIFF
--- a/.github/workflows/update-factions.yml
+++ b/.github/workflows/update-factions.yml
@@ -272,6 +272,15 @@ jobs:
               echo "Created PR for $DISPLAY_NAME v$VER"
             fi
 
+            # Enable auto-merge: the PR merges itself once the required status
+            # checks pass (main requires checks but no reviews). This runs under
+            # the app token, so the eventual merge commit is app-authored and
+            # triggers the Faction Data Release + deploy workflows — a merge made
+            # with GITHUB_TOKEN would not trigger them, stranding the deploy.
+            gh pr merge "$BRANCH" --squash --auto \
+              && echo "Auto-merge enabled for $DISPLAY_NAME v$VER" \
+              || echo "Could not enable auto-merge for $DISPLAY_NAME v$VER (continuing)"
+
             # Return to the working branch with all regenerated data
             git checkout -
           done


### PR DESCRIPTION
## Summary

Faction update PRs now enable **auto-merge (squash)** as soon as they're created/refreshed, so they merge themselves once `main`'s required status checks pass. No more manually merging each daily faction PR.

## Why it works the way it does

- `main` requires the 4 status checks (CLI, Web, E2E, CodeQL) but **0 reviews**, so auto-merge needs no approval step — it just waits for the checks. (`allow_auto_merge` is already enabled on the repo.)
- Auto-merge is enabled **under the app token**, not `GITHUB_TOKEN`. This is essential: a merge performed via `GITHUB_TOKEN` pushes to `main` *without triggering workflows* (the recursion guard), which would merge the PR but never fire `faction-data.yml` / `deploy.yml`. An app-authored merge **does** trigger them, so publish + deploy run end-to-end. (Same reason the workflow already uses the app token to *create* the PRs so CI runs.)
- Enabling auto-merge is best-effort (`|| echo …`) — a failure is logged and the run continues.

## Interaction with recent fixes
- Pairs with #374 (refresh stale PR) — if a check fails or there's a conflict, the PR stays open and gets refreshed next run.
- Pairs with #377 (version-number ordering) — even if PRs auto-merge out of order, "latest" is correct.

## ⚠️ Tradeoff to be aware of
This removes the human review gate on faction data — green CI auto-publishes to the live site. The required checks validate **code** (CLI/Web/E2E/CodeQL), not faction-data *correctness*. If you want a safety net later, a data-sanity check (e.g. unit-count delta threshold) could be added as a required check. Shipping as requested.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)