### PR TITLE
fix(web): stop stale index.html caching that blanks the live site

### DIFF
--- a/web/public/_headers
+++ b/web/public/_headers
@@ -1,0 +1,22 @@
+# Cloudflare Pages response headers.
+#
+# Why: each deploy fingerprints the JS/CSS bundles with a new hash and removes
+# the previous ones. If index.html is cached, a stale copy keeps pointing at a
+# bundle the latest deploy deleted -> Pages serves the SPA fallback HTML for the
+# missing .js -> the browser tries to parse HTML as a module -> blank page.
+#
+# So: never cache the HTML entry (always revalidate), and cache the
+# content-hashed assets forever (their URL changes when content changes).
+#
+# NOTE: For these to reach the browser on the custom domain, the Cloudflare
+# zone's Browser Cache TTL must be set to "Respect Existing Headers". Otherwise
+# the zone rewrites Cache-Control on every response (currently forcing
+# max-age=14400), which is what caused the outage.
+
+/
+  Cache-Control: public, max-age=0, must-revalidate
+/index.html
+  Cache-Control: public, max-age=0, must-revalidate
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
## Problem

The live site (`pa-pedia.com`) renders a **blank page** after deploys that change the JS bundle hash (e.g. the Tailwind v4 / Vite 8 upgrade).

Root cause is **caching, not the package updates**:

1. Each deploy fingerprints `index-<hash>.js`/`.css` and deletes the previous bundle.
2. The Cloudflare zone overrides `Cache-Control` on **every** response — including `index.html` — with a 4-hour Browser Cache TTL (`max-age=14400`).
3. Browsers/edge serve a stale `index.html` referencing the **previous** JS bundle, which the latest deploy already deleted.
4. Pages serves the SPA fallback HTML for the missing `.js`; the browser parses HTML as a module (`Unexpected token '<'`), React never mounts → blank page.

### Evidence

| Origin | `index.html` `Cache-Control` |
|--------|------------------------------|
| `pa-pedia.pages.dev` (raw Pages) | `max-age=0, must-revalidate` ✓ |
| `pa-pedia.com` (zone) | `max-age=14400, must-revalidate` ✗ |

A cache-bypassing fetch of `pa-pedia.com` returns a correct `index.html` (points at the live `index-CNHvsTlI.js`, 200/real JS); the cached copy users got points at the deleted `index-BQSzKhJq.js` (200 but HTML fallback).

## Change

Adds `web/public/_headers` so Cloudflare Pages emits:
- `/` and `/index.html` → `max-age=0, must-revalidate` (always revalidate)
- `/assets/*` → `max-age=31536000, immutable` (content-hashed, safe to cache forever)

## Required dashboard changes (not in this PR)

These headers only reach the browser once the zone stops rewriting them:
1. **Purge cache** (Caching → Purge Everything) — restores the currently-broken live site immediately.
2. **Browser Cache TTL → "Respect Existing Headers"** — permanent fix so `index.html` is never cached stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)