### PR TITLE
feat(web): "What changed?" version-diff modal on faction pages

### DIFF
--- a/web/src/components/VersionDiffModal.tsx
+++ b/web/src/components/VersionDiffModal.tsx
@@ -1,0 +1,272 @@
+import { useEffect, useMemo } from 'react'
+import { Link } from 'react-router-dom'
+import { useFaction } from '@/hooks/useFaction'
+import { UnitIcon } from '@/components/UnitIcon'
+import {
+  diffFactionVersions,
+  hasChanges,
+  type UnitRef,
+  type ChangedUnit,
+} from '@/utils/versionDiff'
+import type { FactionIndex } from '@/types/faction'
+
+interface VersionDiffModalProps {
+  isOpen: boolean
+  onClose: () => void
+  factionId: string
+  /** Older version: both the display label and the key used to load its data. */
+  previousVersion: string
+  /** Newer version being viewed (display label only). */
+  currentVersion: string
+  /** Already-loaded index for the current version. */
+  currentIndex: FactionIndex
+}
+
+/**
+ * Modal that shows a human-readable, computed diff between the faction version
+ * currently being viewed and the immediately previous version.
+ *
+ * Loading of the previous version's data is deferred: the body (which triggers
+ * the fetch via {@link useFaction}) is only mounted while the modal is open.
+ */
+export function VersionDiffModal({
+  isOpen,
+  onClose,
+  factionId,
+  previousVersion,
+  currentVersion,
+  currentIndex,
+}: VersionDiffModalProps) {
+  // Close on Escape while open
+  useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose()
+    }
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscape)
+      return () => document.removeEventListener('keydown', handleEscape)
+    }
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="version-diff-title"
+    >
+      <div
+        className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-3xl w-full max-h-[90vh] min-h-[300px] flex flex-col overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700 flex-shrink-0">
+          <h2 id="version-diff-title" className="text-xl font-bold text-gray-900 dark:text-gray-100">
+            What changed: <span className="font-mono">v{previousVersion}</span>
+            {' → '}
+            <span className="font-mono">v{currentVersion}</span>
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 text-3xl leading-none w-8 h-8 flex items-center justify-center rounded hover:bg-gray-100 dark:hover:bg-gray-700"
+            aria-label="Close"
+          >
+            &times;
+          </button>
+        </div>
+
+        {/* Body (deferred load) */}
+        <div className="flex-1 overflow-auto p-4 min-h-0">
+          <VersionDiffBody
+            factionId={factionId}
+            previousVersion={previousVersion}
+            currentVersion={currentVersion}
+            currentIndex={currentIndex}
+            onNavigate={onClose}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface VersionDiffBodyProps {
+  factionId: string
+  previousVersion: string
+  currentVersion: string
+  currentIndex: FactionIndex
+  onNavigate: () => void
+}
+
+function VersionDiffBody({
+  factionId,
+  previousVersion,
+  currentVersion,
+  currentIndex,
+  onNavigate,
+}: VersionDiffBodyProps) {
+  const { index: previousIndex, loading, error, retry } = useFaction(factionId, previousVersion)
+
+  const diff = useMemo(() => {
+    if (!previousIndex) return null
+    return diffFactionVersions(previousIndex, currentIndex, previousVersion, currentVersion)
+  }, [previousIndex, currentIndex, previousVersion, currentVersion])
+
+  if (error) {
+    return (
+      <div className="text-center py-8">
+        <p className="text-red-600 dark:text-red-400 mb-3">
+          Failed to load v{previousVersion} for comparison.
+        </p>
+        <button
+          onClick={retry}
+          className="px-4 py-2 border rounded-md bg-background hover:bg-muted transition-colors text-sm"
+        >
+          Retry
+        </button>
+      </div>
+    )
+  }
+
+  if (loading || !diff) {
+    return (
+      <div className="flex items-center justify-center py-12 text-muted-foreground">
+        Loading v{previousVersion}…
+      </div>
+    )
+  }
+
+  if (!hasChanges(diff)) {
+    return (
+      <div className="text-center py-12 text-muted-foreground">
+        No tracked changes between v{previousVersion} and v{currentVersion}.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {diff.added.length > 0 && (
+        <DiffSection
+          title="Added"
+          count={diff.added.length}
+          accentClass="text-green-600 dark:text-green-400"
+        >
+          {diff.added.map((unit) => (
+            <UnitRow key={unit.identifier} factionId={factionId} unit={unit} onNavigate={onNavigate} />
+          ))}
+        </DiffSection>
+      )}
+
+      {diff.changed.length > 0 && (
+        <DiffSection
+          title="Changed"
+          count={diff.changed.length}
+          accentClass="text-amber-600 dark:text-amber-400"
+        >
+          {diff.changed.map((unit) => (
+            <ChangedUnitRow key={unit.identifier} factionId={factionId} unit={unit} onNavigate={onNavigate} />
+          ))}
+        </DiffSection>
+      )}
+
+      {diff.removed.length > 0 && (
+        <DiffSection
+          title="Removed"
+          count={diff.removed.length}
+          accentClass="text-red-600 dark:text-red-400"
+        >
+          {diff.removed.map((unit) => (
+            <UnitRow key={unit.identifier} factionId={factionId} unit={unit} onNavigate={onNavigate} linkable={false} />
+          ))}
+        </DiffSection>
+      )}
+    </div>
+  )
+}
+
+interface DiffSectionProps {
+  title: string
+  count: number
+  accentClass: string
+  children: React.ReactNode
+}
+
+function DiffSection({ title, count, accentClass, children }: DiffSectionProps) {
+  return (
+    <section>
+      <h3 className={`text-sm font-semibold uppercase tracking-wide mb-2 ${accentClass}`}>
+        {title} ({count})
+      </h3>
+      <ul className="space-y-2">{children}</ul>
+    </section>
+  )
+}
+
+interface UnitRowProps {
+  factionId: string
+  unit: UnitRef
+  onNavigate: () => void
+  /** Removed units no longer exist in the current version, so don't link them. */
+  linkable?: boolean
+}
+
+function UnitRow({ factionId, unit, onNavigate, linkable = true }: UnitRowProps) {
+  const content = (
+    <span className="flex items-center gap-2">
+      <span className="w-7 h-7 flex-shrink-0 flex items-center justify-center bg-muted rounded">
+        <UnitIcon imagePath={unit.image} alt={unit.displayName} className="w-6 h-6" factionId={factionId} />
+      </span>
+      <span className="text-sm font-semibold">{unit.displayName}</span>
+    </span>
+  )
+
+  if (!linkable) {
+    return <li className="text-muted-foreground line-through">{content}</li>
+  }
+
+  return (
+    <li>
+      <Link
+        to={`/faction/${factionId}/unit/${unit.identifier}`}
+        onClick={onNavigate}
+        className="inline-flex hover:text-primary transition-colors"
+      >
+        {content}
+      </Link>
+    </li>
+  )
+}
+
+interface ChangedUnitRowProps {
+  factionId: string
+  unit: ChangedUnit
+  onNavigate: () => void
+}
+
+function ChangedUnitRow({ factionId, unit, onNavigate }: ChangedUnitRowProps) {
+  return (
+    <li className="bg-muted/50 rounded-md p-2">
+      <Link
+        to={`/faction/${factionId}/unit/${unit.identifier}`}
+        onClick={onNavigate}
+        className="inline-flex items-center gap-2 hover:text-primary transition-colors"
+      >
+        <span className="w-7 h-7 flex-shrink-0 flex items-center justify-center bg-muted rounded">
+          <UnitIcon imagePath={unit.image} alt={unit.displayName} className="w-6 h-6" factionId={factionId} />
+        </span>
+        <span className="text-sm font-semibold">{unit.displayName}</span>
+      </Link>
+      <ul className="mt-1 ml-9 list-disc list-inside space-y-0.5">
+        {unit.fields.map((field) => (
+          <li key={field.label} className="text-xs font-mono text-muted-foreground">
+            {field.display}
+          </li>
+        ))}
+      </ul>
+    </li>
+  )
+}

--- a/web/src/components/__tests__/VersionDiffModal.test.tsx
+++ b/web/src/components/__tests__/VersionDiffModal.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+import { VersionDiffModal } from '../VersionDiffModal'
+import { CurrentFactionProvider } from '@/contexts/CurrentFactionContext'
+import { renderWithFactionProvider } from '@/tests/helpers'
+import { setupMockFetch, mockMLAIndex } from '@/tests/mocks/factionData'
+import type { FactionIndex } from '@/types/faction'
+
+/**
+ * In standard test/dev mode a versioned index load ignores the version and serves
+ * the base `units.json` (see loadFactionIndex). So the mock serves `mockMLAIndex`
+ * as the "previous" version, and we pass a tweaked `currentIndex` to produce a diff.
+ */
+function cloneMLAIndex(): FactionIndex {
+  return structuredClone(mockMLAIndex)
+}
+
+function renderModal(props: {
+  isOpen: boolean
+  onClose: () => void
+  currentIndex: FactionIndex
+  previousVersion?: string
+  currentVersion?: string
+}) {
+  const { previousVersion = '0.9.0', currentVersion = '1.0.0', ...rest } = props
+  return renderWithFactionProvider(
+    <BrowserRouter>
+      <CurrentFactionProvider factionId="MLA">
+        <VersionDiffModal
+          factionId="MLA"
+          previousVersion={previousVersion}
+          currentVersion={currentVersion}
+          {...rest}
+        />
+      </CurrentFactionProvider>
+    </BrowserRouter>
+  )
+}
+
+describe('VersionDiffModal', () => {
+  const mockOnClose = vi.fn()
+
+  beforeEach(() => {
+    setupMockFetch()
+    mockOnClose.mockClear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not render when closed', () => {
+    renderModal({ isOpen: false, onClose: mockOnClose, currentIndex: cloneMLAIndex() })
+    expect(screen.queryByText(/what changed/i)).not.toBeInTheDocument()
+  })
+
+  it('renders the version labels in the header when open', () => {
+    renderModal({ isOpen: true, onClose: mockOnClose, currentIndex: cloneMLAIndex() })
+    expect(screen.getByText(/what changed/i)).toBeInTheDocument()
+    expect(screen.getByText('v0.9.0')).toBeInTheDocument()
+    expect(screen.getByText('v1.0.0')).toBeInTheDocument()
+  })
+
+  it('calls onClose when the close button is clicked', () => {
+    renderModal({ isOpen: true, onClose: mockOnClose, currentIndex: cloneMLAIndex() })
+    fireEvent.click(screen.getByLabelText('Close'))
+    expect(mockOnClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose when the backdrop is clicked', () => {
+    renderModal({ isOpen: true, onClose: mockOnClose, currentIndex: cloneMLAIndex() })
+    const dialog = screen.getByRole('dialog')
+    fireEvent.click(dialog)
+    expect(mockOnClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose when Escape is pressed', () => {
+    renderModal({ isOpen: true, onClose: mockOnClose, currentIndex: cloneMLAIndex() })
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(mockOnClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows a humanised changed-field diff', async () => {
+    const current = cloneMLAIndex()
+    const tank = current.units.find((u) => u.identifier === 'tank')!
+    tank.unit.specs.combat.health = 250 // was 200
+
+    renderModal({ isOpen: true, onClose: mockOnClose, currentIndex: current })
+
+    await waitFor(() => {
+      expect(screen.getByText(/Changed \(1\)/)).toBeInTheDocument()
+    })
+    expect(screen.getByText('Health: 200 → 250 (+25%)')).toBeInTheDocument()
+  })
+
+  it('detects added and removed units', async () => {
+    const current = cloneMLAIndex()
+    // Remove the bot (removed unit) and add a brand-new unit (added unit)
+    current.units = current.units.filter((u) => u.identifier !== 'bot')
+    const tank = current.units.find((u) => u.identifier === 'tank')!
+    current.units.push({
+      ...tank,
+      identifier: 'new_unit',
+      displayName: 'New Unit',
+      unit: { ...tank.unit, id: 'new_unit', displayName: 'New Unit' },
+    })
+
+    renderModal({ isOpen: true, onClose: mockOnClose, currentIndex: current })
+
+    await waitFor(() => {
+      expect(screen.getByText(/Added \(1\)/)).toBeInTheDocument()
+    })
+    expect(screen.getByText('New Unit')).toBeInTheDocument()
+    expect(screen.getByText(/Removed \(1\)/)).toBeInTheDocument()
+    expect(screen.getByText('Bot')).toBeInTheDocument()
+  })
+
+  it('shows an empty state when nothing changed', async () => {
+    renderModal({ isOpen: true, onClose: mockOnClose, currentIndex: cloneMLAIndex() })
+
+    await waitFor(() => {
+      expect(screen.getByText(/No tracked changes/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/web/src/pages/FactionDetail.tsx
+++ b/web/src/pages/FactionDetail.tsx
@@ -10,10 +10,12 @@ import { UnitListView } from '@/components/UnitListView'
 import { UnitIcon } from '@/components/UnitIcon'
 import { FactionSelector } from '@/components/FactionSelector'
 import { VersionSelector } from '@/components/VersionSelector'
+import { VersionDiffModal } from '@/components/VersionDiffModal'
+import { getFactionVersions, isDevelopmentMode, type VersionEntry } from '@/services/manifestLoader'
 import { SEO } from '@/components/SEO'
 import { JsonLd } from '@/components/JsonLd'
 import { createWebPageSchema } from '@/components/seoSchemas'
-import { useState, useCallback, useMemo } from 'react'
+import { useState, useCallback, useMemo, useEffect } from 'react'
 import { parseFactionRef } from '@/utils/versionedFactionId'
 import { groupUnitsByCategory, type UnitCategory } from '@/utils/unitCategories'
 import { groupCommanderVariants } from '@/utils/commanderDedup'
@@ -78,6 +80,50 @@ export function FactionDetail() {
   const [brokenImages, setBrokenImages] = useState<Set<string>>(new Set())
   const [activeCategory, setActiveCategory] = useState<UnitCategory | null>(null)
   const [dragAnnouncement, setDragAnnouncement] = useState('')
+
+  // Version diff: load the version list so we can offer a "What changed?" comparison
+  // against the immediately-previous version. Mirrors VersionSelector's manifest guard.
+  const [versionList, setVersionList] = useState<VersionEntry[]>([])
+  const [diffOpen, setDiffOpen] = useState(false)
+  useEffect(() => {
+    let cancelled = false
+    // Clear immediately when factionId changes to avoid showing a stale comparison.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setVersionList([])
+    const hasManifest =
+      !isDevelopmentMode() ||
+      import.meta.env.VITE_USE_LIVE_DATA === 'true' ||
+      !!import.meta.env.VITE_FACTIONS_DIR
+    if (isAllMode || !factionId || isLocalFaction(factionId) || !hasManifest) {
+      return
+    }
+    getFactionVersions(factionId)
+      .then((list) => {
+        if (!cancelled) setVersionList(list)
+      })
+      .catch(() => {
+        if (!cancelled) setVersionList([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [factionId, isAllMode, isLocalFaction])
+
+  // Resolve the version currently being viewed (null = latest = versions[0]) and the
+  // immediately-older version to diff against, if one exists.
+  const { currentVersionLabel, previousVersion } = useMemo(() => {
+    if (versionList.length <= 1) {
+      return { currentVersionLabel: null as string | null, previousVersion: null as string | null }
+    }
+    const currentIdx = version ? versionList.findIndex((v) => v.version === version) : 0
+    if (currentIdx === -1) {
+      return { currentVersionLabel: null as string | null, previousVersion: null as string | null }
+    }
+    return {
+      currentVersionLabel: versionList[currentIdx].version,
+      previousVersion: versionList[currentIdx + 1]?.version ?? null,
+    }
+  }, [versionList, version])
 
   // Convert saved collapsed categories array to Set for efficient lookups
   const collapsedCategories = useMemo(
@@ -368,12 +414,24 @@ export function FactionDetail() {
         </div>
         {/* Version selector - only show for non-local factions with multiple versions */}
         {!isAllMode && !isLocalFaction(factionId) && (
-          <div className="w-full sm:w-auto sm:flex-none">
+          <div className="w-full sm:w-auto sm:flex-none flex items-center gap-2">
             <VersionSelector
               factionId={factionId}
               currentVersion={version}
               onVersionChange={handleVersionChange}
             />
+            {/* "What changed?" - only when an older version exists and the current
+                index is loaded (needed to compute the diff). */}
+            {previousVersion && currentVersionLabel && singleFaction.index && (
+              <button
+                type="button"
+                onClick={() => setDiffOpen(true)}
+                className="px-3 py-2 border rounded-md bg-background hover:bg-muted transition-colors text-sm font-medium whitespace-nowrap"
+                title={`Compare v${currentVersionLabel} against v${previousVersion}`}
+              >
+                What changed?
+              </button>
+            )}
           </div>
         )}
         {/* Row 2 on mobile: Search (full width) */}
@@ -533,6 +591,17 @@ export function FactionDetail() {
           </button>
         </div>
       </div>
+
+      {previousVersion && currentVersionLabel && singleFaction.index && (
+        <VersionDiffModal
+          isOpen={diffOpen}
+          onClose={() => setDiffOpen(false)}
+          factionId={factionId}
+          previousVersion={previousVersion}
+          currentVersion={currentVersionLabel}
+          currentIndex={singleFaction.index}
+        />
+      )}
 
       {viewMode === 'table' ? (
           <UnitTable

--- a/web/src/utils/__tests__/versionDiff.test.ts
+++ b/web/src/utils/__tests__/versionDiff.test.ts
@@ -100,14 +100,63 @@ describe('diffFactionVersions', () => {
     expect(accessibleChange?.display).toBe('Accessible: No → Yes')
   })
 
-  it('skips fields absent on either version', () => {
+  it('reports a field that newly appears in the new version', () => {
     const previous = makeIndex([makeEntry('tank', makeUnit({ specs: { combat: { health: 200 }, economy: { buildCost: 150 } } }))])
     const current = makeIndex([makeEntry('tank', makeUnit({ specs: { combat: { health: 200, dps: 99 }, economy: { buildCost: 150 } } }))])
 
     const diff = diffFactionVersions(previous, current, '1.0.0', '1.1.0')
 
-    // dps was undefined in the previous version, so it must not be reported as a change
-    expect(diff.changed).toHaveLength(0)
+    const dpsChange = diff.changed[0].fields.find((f) => f.label === 'DPS')
+    expect(dpsChange?.display).toBe('DPS: – → 99')
+  })
+
+  it('diffs nested weapon stats labelled by weapon name', () => {
+    const weapon = (damage: number, rateOfFire: number) => ({
+      resourceName: '/w.json',
+      safeName: 'main',
+      name: 'Main Cannon',
+      count: 1,
+      rateOfFire,
+      damage,
+      dps: damage * rateOfFire,
+    })
+    const previous = makeIndex([makeEntry('tank', makeUnit({ specs: { combat: { health: 200, weapons: [weapon(10, 9)] }, economy: { buildCost: 150 } } }))])
+    const current = makeIndex([makeEntry('tank', makeUnit({ specs: { combat: { health: 200, weapons: [weapon(45, 2)] }, economy: { buildCost: 150 } } }))])
+
+    const diff = diffFactionVersions(previous, current, '1.0.0', '1.1.0')
+
+    const displays = diff.changed[0].fields.map((f) => f.display)
+    expect(displays).toContain('Main Cannon damage: 10 → 45 (+350%)')
+    expect(displays).toContain('Main Cannon rate of fire: 9 → 2 (-78%)')
+  })
+
+  it('reports unit type additions and removals as a set change', () => {
+    const previous = makeIndex([makeEntry('tank', makeUnit({ unitTypes: ['Mobile', 'Land', 'Tank'] }))])
+    const current = makeIndex([makeEntry('tank', makeUnit({ unitTypes: ['Mobile', 'Land', 'Stealth'] }))])
+
+    const diff = diffFactionVersions(previous, current, '1.0.0', '1.1.0')
+
+    const typeChange = diff.changed[0].fields.find((f) => f.label === 'Unit types')
+    expect(typeChange?.display).toBe('Unit types: +Stealth  −Tank')
+  })
+
+  it('summarises build-relationship changes using display names', () => {
+    const previous = makeIndex([
+      makeEntry('tank', makeUnit({ buildRelationships: { builtBy: ['vehicle_factory'] } })),
+      makeEntry('vehicle_factory', makeUnit({ displayName: 'Vehicle Factory' }), 'Vehicle Factory'),
+      makeEntry('adv_factory', makeUnit({ displayName: 'Advanced Factory' }), 'Advanced Factory'),
+    ])
+    const current = makeIndex([
+      makeEntry('tank', makeUnit({ buildRelationships: { builtBy: ['adv_factory'] } })),
+      makeEntry('vehicle_factory', makeUnit({ displayName: 'Vehicle Factory' }), 'Vehicle Factory'),
+      makeEntry('adv_factory', makeUnit({ displayName: 'Advanced Factory' }), 'Advanced Factory'),
+    ])
+
+    const diff = diffFactionVersions(previous, current, '1.0.0', '1.1.0')
+
+    const tank = diff.changed.find((u) => u.identifier === 'tank')!
+    const builtBy = tank.fields.find((f) => f.label === 'Built by')
+    expect(builtBy?.display).toBe('Built by: +Advanced Factory  −Vehicle Factory')
   })
 
   it('returns an empty diff when nothing changed', () => {

--- a/web/src/utils/__tests__/versionDiff.test.ts
+++ b/web/src/utils/__tests__/versionDiff.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest'
+import { diffFactionVersions, hasChanges } from '../versionDiff'
+import type { FactionIndex, Unit, UnitIndexEntry } from '@/types/faction'
+
+/** Minimal unit factory for diff tests. */
+function makeUnit(overrides: Partial<Unit> = {}): Unit {
+  return {
+    id: 'tank',
+    resourceName: '/pa/units/land/tank/tank.json',
+    displayName: 'Tank',
+    image: 'assets/pa/units/land/tank/tank_icon_buildbar.png',
+    tier: 1,
+    unitTypes: ['Mobile', 'Land', 'Basic', 'Tank'],
+    accessible: true,
+    specs: {
+      combat: { health: 200, dps: 50 },
+      economy: { buildCost: 150, buildRate: 0 },
+      mobility: { moveSpeed: 10 },
+    },
+    ...overrides,
+  }
+}
+
+function makeEntry(identifier: string, unit: Unit, displayName?: string): UnitIndexEntry {
+  return {
+    identifier,
+    displayName: displayName ?? unit.displayName,
+    unitTypes: unit.unitTypes,
+    source: unit.resourceName,
+    files: [],
+    unit,
+  }
+}
+
+function makeIndex(entries: UnitIndexEntry[]): FactionIndex {
+  return { units: entries }
+}
+
+describe('diffFactionVersions', () => {
+  it('detects added units', () => {
+    const previous = makeIndex([makeEntry('tank', makeUnit())])
+    const current = makeIndex([
+      makeEntry('tank', makeUnit()),
+      makeEntry('bomber', makeUnit({ displayName: 'Bomber' }), 'Bomber'),
+    ])
+
+    const diff = diffFactionVersions(previous, current, '1.0.0', '1.1.0')
+
+    expect(diff.added).toHaveLength(1)
+    expect(diff.added[0]).toMatchObject({ identifier: 'bomber', displayName: 'Bomber' })
+    expect(diff.removed).toHaveLength(0)
+    expect(diff.changed).toHaveLength(0)
+  })
+
+  it('detects removed units', () => {
+    const previous = makeIndex([
+      makeEntry('tank', makeUnit()),
+      makeEntry('mine', makeUnit({ displayName: 'Mine' }), 'Mine'),
+    ])
+    const current = makeIndex([makeEntry('tank', makeUnit())])
+
+    const diff = diffFactionVersions(previous, current, '1.0.0', '1.1.0')
+
+    expect(diff.removed).toHaveLength(1)
+    expect(diff.removed[0].identifier).toBe('mine')
+    expect(diff.added).toHaveLength(0)
+  })
+
+  it('detects changed numeric fields with signed percentage', () => {
+    const previous = makeIndex([makeEntry('tank', makeUnit({ specs: { combat: { health: 200, dps: 50 }, economy: { buildCost: 150 } } }))])
+    const current = makeIndex([makeEntry('tank', makeUnit({ specs: { combat: { health: 250, dps: 50 }, economy: { buildCost: 150 } } }))])
+
+    const diff = diffFactionVersions(previous, current, '1.0.0', '1.1.0')
+
+    expect(diff.changed).toHaveLength(1)
+    const healthChange = diff.changed[0].fields.find((f) => f.label === 'Health')
+    expect(healthChange).toBeDefined()
+    expect(healthChange?.before).toBe(200)
+    expect(healthChange?.after).toBe(250)
+    expect(healthChange?.display).toBe('Health: 200 → 250 (+25%)')
+  })
+
+  it('renders a downward change with a negative percentage', () => {
+    const previous = makeIndex([makeEntry('tank', makeUnit({ specs: { combat: { health: 200, dps: 50 }, economy: { buildCost: 200 } } }))])
+    const current = makeIndex([makeEntry('tank', makeUnit({ specs: { combat: { health: 200, dps: 50 }, economy: { buildCost: 150 } } }))])
+
+    const diff = diffFactionVersions(previous, current, '1.0.0', '1.1.0')
+
+    const costChange = diff.changed[0].fields.find((f) => f.label === 'Build cost')
+    expect(costChange?.display).toBe('Build cost: 200 → 150 (-25%)')
+  })
+
+  it('renders boolean accessibility changes without a percentage', () => {
+    const previous = makeIndex([makeEntry('tank', makeUnit({ accessible: false }))])
+    const current = makeIndex([makeEntry('tank', makeUnit({ accessible: true }))])
+
+    const diff = diffFactionVersions(previous, current, '1.0.0', '1.1.0')
+
+    const accessibleChange = diff.changed[0].fields.find((f) => f.label === 'Accessible')
+    expect(accessibleChange?.display).toBe('Accessible: No → Yes')
+  })
+
+  it('skips fields absent on either version', () => {
+    const previous = makeIndex([makeEntry('tank', makeUnit({ specs: { combat: { health: 200 }, economy: { buildCost: 150 } } }))])
+    const current = makeIndex([makeEntry('tank', makeUnit({ specs: { combat: { health: 200, dps: 99 }, economy: { buildCost: 150 } } }))])
+
+    const diff = diffFactionVersions(previous, current, '1.0.0', '1.1.0')
+
+    // dps was undefined in the previous version, so it must not be reported as a change
+    expect(diff.changed).toHaveLength(0)
+  })
+
+  it('returns an empty diff when nothing changed', () => {
+    const previous = makeIndex([makeEntry('tank', makeUnit())])
+    const current = makeIndex([makeEntry('tank', makeUnit())])
+
+    const diff = diffFactionVersions(previous, current, '1.0.0', '1.1.0')
+
+    expect(hasChanges(diff)).toBe(false)
+  })
+
+  it('sorts results alphabetically by display name', () => {
+    const previous = makeIndex([])
+    const current = makeIndex([
+      makeEntry('zebra', makeUnit({ displayName: 'Zebra' }), 'Zebra'),
+      makeEntry('alpha', makeUnit({ displayName: 'Alpha' }), 'Alpha'),
+    ])
+
+    const diff = diffFactionVersions(previous, current, '1.0.0', '1.1.0')
+
+    expect(diff.added.map((u) => u.displayName)).toEqual(['Alpha', 'Zebra'])
+  })
+
+  it('preserves the from/to version labels', () => {
+    const diff = diffFactionVersions(makeIndex([]), makeIndex([]), '0.7.0', '0.7.1')
+    expect(diff.fromVersion).toBe('0.7.0')
+    expect(diff.toVersion).toBe('0.7.1')
+  })
+})

--- a/web/src/utils/versionDiff.ts
+++ b/web/src/utils/versionDiff.ts
@@ -3,8 +3,17 @@
  *
  * PA-Pedia has no authored changelog, so "what changed" is derived by comparing
  * the embedded, fully-resolved unit specs of two faction indexes. Units are keyed
- * by `identifier`; a curated set of high-signal fields is compared to keep the
- * resulting list readable.
+ * by `identifier`.
+ *
+ * The diff is comprehensive: it walks the whole resolved spec tree so any
+ * meaningful change is surfaced (weapon damage, fire rate, ranges, ammo, economy,
+ * mobility, recon, etc.) rather than a hand-picked subset. Two categories get
+ * special treatment:
+ *   - Internal/derived keys (ids, resource paths, icon paths, raw ammo blobs) are
+ *     skipped — they're not player-facing.
+ *   - `buildRelationships` (the build graph) is summarised, not diffed edge-by-edge:
+ *     adding/removing a single builder unit otherwise produces hundreds of low-signal
+ *     "now built by X" bullets that bury the real balance changes.
  */
 import type { FactionIndex, UnitIndexEntry, Unit } from '@/types/faction'
 import { formatNumber } from '@/utils/groupAggregation'
@@ -19,8 +28,8 @@ export interface UnitRef {
 /** A single changed field on a unit, pre-formatted for display. */
 export interface FieldChange {
   label: string
-  before: number | boolean | null
-  after: number | boolean | null
+  before: number | boolean | string | null
+  after: number | boolean | string | null
   /** Humanised one-line summary, e.g. "Health: 200 → 250 (+25%)". */
   display: string
 }
@@ -39,28 +48,238 @@ export interface VersionDiff {
   changed: ChangedUnit[]
 }
 
-type FieldKind = 'number' | 'bool'
+/**
+ * Keys skipped while walking a unit. These are internal identifiers, file paths,
+ * or raw sub-blobs whose meaningful values are already surfaced at a higher level
+ * (e.g. resolved weapon stats supersede raw `ammoDetails`). `buildRelationships`
+ * is excluded here because it's summarised separately.
+ */
+const INTERNAL_KEYS = new Set([
+  'id',
+  'resourceName',
+  'safeName',
+  'image',
+  'baseTemplate',
+  'buildRelationships',
+  'ammoDetails',
+  'buildableAmmo',
+])
 
-interface TrackedField {
-  label: string
-  kind: FieldKind
-  accessor: (unit: Unit) => number | boolean | undefined
+/**
+ * Container keys whose own name is dropped from field labels, so nested leaves
+ * read naturally: `specs.combat.health` → "Health", not "Specs combat health".
+ */
+const TRANSPARENT_KEYS = new Set(['specs', 'combat', 'economy', 'mobility', 'recon', 'special'])
+
+/** Nicer labels for keys that don't humanise well from camelCase alone. */
+const LABEL_OVERRIDES: Record<string, string> = {
+  displayName: 'Name',
+  dps: 'DPS',
+  sustainedDps: 'Sustained DPS',
+  buildCost: 'Build cost',
+  buildRate: 'Build rate',
+  buildRange: 'Build range',
+  moveSpeed: 'Move speed',
+  turnSpeed: 'Turn speed',
+  rateOfFire: 'Rate of fire',
+  maxRange: 'Range',
+  salvoDamage: 'Salvo damage',
+  splashDamage: 'Splash damage',
+  splashRadius: 'Splash radius',
+  unitTypes: 'Unit types',
+  buildableTypes: 'Buildable types',
+  metalRate: 'Metal rate',
+  energyRate: 'Energy rate',
+  visionRadius: 'Vision radius',
+  radarRadius: 'Radar radius',
+  sonarRadius: 'Sonar radius',
+  muzzleVelocity: 'Muzzle velocity',
+}
+
+function humanise(key: string): string {
+  if (LABEL_OVERRIDES[key]) return LABEL_OVERRIDES[key]
+  const spaced = key.replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1).toLowerCase()
+}
+
+/** Combine a parent label with a child key, keeping the first word capitalised. */
+function appendLabel(parent: string, key: string): string {
+  const h = humanise(key)
+  return parent ? `${parent} ${h.toLowerCase()}` : h
+}
+
+function truncate(value: string, max = 60): string {
+  return value.length > max ? `${value.slice(0, max - 1)}…` : value
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+/** Format a single scalar (number/boolean/string) change into a display bullet. */
+function formatScalarChange(label: string, before: unknown, after: unknown): FieldChange {
+  const beforeIsNum = typeof before === 'number'
+  const afterIsNum = typeof after === 'number'
+  const beforeIsBool = typeof before === 'boolean'
+  const afterIsBool = typeof after === 'boolean'
+
+  let display: string
+  let beforeVal: FieldChange['before']
+  let afterVal: FieldChange['after']
+
+  if (beforeIsBool || afterIsBool) {
+    const bs = before === undefined ? '–' : before ? 'Yes' : 'No'
+    const as_ = after === undefined ? '–' : after ? 'Yes' : 'No'
+    display = `${label}: ${bs} → ${as_}`
+    beforeVal = beforeIsBool ? (before as boolean) : null
+    afterVal = afterIsBool ? (after as boolean) : null
+  } else if (beforeIsNum || afterIsNum) {
+    const bs = beforeIsNum ? formatNumber(before as number) : '–'
+    const as_ = afterIsNum ? formatNumber(after as number) : '–'
+    display = `${label}: ${bs} → ${as_}`
+    if (beforeIsNum && afterIsNum && (before as number) > 0) {
+      const pct = Math.round((((after as number) - (before as number)) / (before as number)) * 100)
+      if (Math.abs(pct) >= 1) display += ` (${pct > 0 ? '+' : ''}${pct}%)`
+    }
+    beforeVal = beforeIsNum ? (before as number) : null
+    afterVal = afterIsNum ? (after as number) : null
+  } else {
+    const bs = before === undefined || before === null ? '–' : `"${truncate(String(before))}"`
+    const as_ = after === undefined || after === null ? '–' : `"${truncate(String(after))}"`
+    display = `${label}: ${bs} → ${as_}`
+    beforeVal = typeof before === 'string' ? before : null
+    afterVal = typeof after === 'string' ? after : null
+  }
+
+  return { label, before: beforeVal, after: afterVal, display }
+}
+
+/** Render an added/removed set as a single bullet, e.g. "Unit types: +Stealth  −Bot". */
+function formatSetChange(label: string, added: string[], removed: string[]): FieldChange {
+  const parts: string[] = []
+  if (added.length) parts.push(`+${added.join(', ')}`)
+  if (removed.length) parts.push(`−${removed.join(', ')}`)
+  return { label, before: null, after: null, display: `${label}: ${parts.join('  ')}` }
+}
+
+function isScalar(value: unknown): boolean {
+  return value === null || typeof value !== 'object'
+}
+
+/** Stable key for matching objects across versions (weapons, build arms, …). */
+function elementKey(element: unknown): string {
+  if (isObject(element)) {
+    return String(element.safeName ?? element.resourceName ?? element.name ?? JSON.stringify(element))
+  }
+  return JSON.stringify(element)
+}
+
+/** A `name` is only used as a label if it reads as human text, not an internal id. */
+function looksHuman(name: string): boolean {
+  return /[ A-Z]/.test(name) && !name.includes('_')
+}
+
+/** Raw name for add/remove lines — informative even when not pretty. */
+function rawElementName(element: unknown, fallback: string): string {
+  if (isObject(element) && typeof element.name === 'string' && element.name) {
+    return element.name
+  }
+  return fallback
 }
 
 /**
- * High-signal fields compared between versions. Order here is the display order.
- * Note: `economy.buildCost` is a flat metal cost in the data model (not a
- * {metal, energy} object), so it is tracked as a single number.
+ * Label used when diffing the fields of a matched array element. Prefers a human
+ * weapon name; otherwise falls back to a singularised container label (e.g.
+ * "Weapons" → "Weapon", numbered when there are several).
  */
-const TRACKED_FIELDS: TrackedField[] = [
-  { label: 'Tier', kind: 'number', accessor: (u) => u.tier },
-  { label: 'Accessible', kind: 'bool', accessor: (u) => u.accessible },
-  { label: 'Health', kind: 'number', accessor: (u) => u.specs?.combat?.health },
-  { label: 'DPS', kind: 'number', accessor: (u) => u.specs?.combat?.dps },
-  { label: 'Build cost', kind: 'number', accessor: (u) => u.specs?.economy?.buildCost },
-  { label: 'Build rate', kind: 'number', accessor: (u) => u.specs?.economy?.buildRate },
-  { label: 'Move speed', kind: 'number', accessor: (u) => u.specs?.mobility?.moveSpeed },
-]
+function elementFieldLabel(element: unknown, containerLabel: string, ordinal: number | null): string {
+  if (isObject(element) && typeof element.name === 'string' && looksHuman(element.name)) {
+    return element.name
+  }
+  const base = containerLabel.replace(/s$/, '')
+  return ordinal != null ? `${base} ${ordinal}` : base
+}
+
+function walkArray(prev: unknown[], curr: unknown[], label: string, out: FieldChange[]): void {
+  // Arrays of scalars (unitTypes, targetLayers, …) → set difference.
+  if (prev.every(isScalar) && curr.every(isScalar)) {
+    const prevSet = new Set(prev.map((v) => String(v)))
+    const currSet = new Set(curr.map((v) => String(v)))
+    const added = [...currSet].filter((v) => !prevSet.has(v))
+    const removed = [...prevSet].filter((v) => !currSet.has(v))
+    if (added.length || removed.length) out.push(formatSetChange(label, added, removed))
+    return
+  }
+
+  // Arrays of objects → match by key, diff per element, report add/remove.
+  const prevMap = new Map(prev.map((e) => [elementKey(e), e]))
+  const currMap = new Map(curr.map((e) => [elementKey(e), e]))
+  const multiple = currMap.size > 1
+
+  let ordinal = 0
+  for (const [key, currEl] of currMap) {
+    ordinal += 1
+    const prevEl = prevMap.get(key)
+    if (!prevEl) {
+      out.push({ label, before: null, after: null, display: `${label}: + ${rawElementName(currEl, key)}` })
+      continue
+    }
+    walk(prevEl, currEl, elementFieldLabel(currEl, label, multiple ? ordinal : null), out)
+  }
+  for (const [key, prevEl] of prevMap) {
+    if (!currMap.has(key)) {
+      out.push({ label, before: null, after: null, display: `${label}: − ${rawElementName(prevEl, key)}` })
+    }
+  }
+}
+
+/** Recursively diff two values, appending humanised field changes to `out`. */
+function walk(prev: unknown, curr: unknown, label: string, out: FieldChange[]): void {
+  const prevIsObj = prev !== null && typeof prev === 'object'
+  const currIsObj = curr !== null && typeof curr === 'object'
+
+  if (prevIsObj || currIsObj) {
+    if (Array.isArray(prev) || Array.isArray(curr)) {
+      walkArray((prev as unknown[]) ?? [], (curr as unknown[]) ?? [], label, out)
+      return
+    }
+    const prevObj = (prevIsObj ? prev : {}) as Record<string, unknown>
+    const currObj = (currIsObj ? curr : {}) as Record<string, unknown>
+    const keys = new Set([...Object.keys(prevObj), ...Object.keys(currObj)])
+    for (const key of keys) {
+      if (INTERNAL_KEYS.has(key)) continue
+      const childLabel = TRANSPARENT_KEYS.has(key) ? label : appendLabel(label, key)
+      walk(prevObj[key], currObj[key], childLabel, out)
+    }
+    return
+  }
+
+  // Both scalar (or undefined).
+  if (prev === undefined && curr === undefined) return
+  if (prev !== curr) out.push(formatScalarChange(label, prev, curr))
+}
+
+/**
+ * Summarise build-graph changes for a unit into at most two bullets, mapping unit
+ * identifiers to display names where possible.
+ */
+function diffBuildRelationships(
+  prev: Unit,
+  curr: Unit,
+  nameMap: Map<string, string>,
+  out: FieldChange[]
+): void {
+  const pretty = (id: string) => nameMap.get(id) ?? id
+  const summarise = (label: string, prevList?: string[], currList?: string[]) => {
+    const prevSet = new Set(prevList ?? [])
+    const currSet = new Set(currList ?? [])
+    const added = [...currSet].filter((id) => !prevSet.has(id)).map(pretty)
+    const removed = [...prevSet].filter((id) => !currSet.has(id)).map(pretty)
+    if (added.length || removed.length) out.push(formatSetChange(label, added, removed))
+  }
+  summarise('Built by', prev.buildRelationships?.builtBy, curr.buildRelationships?.builtBy)
+  summarise('Builds', prev.buildRelationships?.builds, curr.buildRelationships?.builds)
+}
 
 function buildMap(index: FactionIndex): Map<string, UnitIndexEntry> {
   const map = new Map<string, UnitIndexEntry>()
@@ -78,41 +297,14 @@ function toRef(entry: UnitIndexEntry): UnitRef {
   }
 }
 
-function formatNumberChange(label: string, before: number, after: number): string {
-  let display = `${label}: ${formatNumber(before)} → ${formatNumber(after)}`
-  if (before > 0) {
-    const pct = Math.round(((after - before) / before) * 100)
-    if (Math.abs(pct) >= 1) {
-      display += ` (${pct > 0 ? '+' : ''}${pct}%)`
+function buildNameMap(...indexes: FactionIndex[]): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const index of indexes) {
+    for (const entry of index.units) {
+      map.set(entry.identifier, entry.displayName || entry.unit?.displayName || entry.identifier)
     }
   }
-  return display
-}
-
-function formatBoolChange(label: string, before: boolean, after: boolean): string {
-  return `${label}: ${before ? 'Yes' : 'No'} → ${after ? 'Yes' : 'No'}`
-}
-
-/**
- * Compare the tracked fields of two unit versions. Fields that are absent on
- * either side are skipped (we can't meaningfully diff a missing value).
- */
-function diffUnitFields(previous: Unit, current: Unit): FieldChange[] {
-  const changes: FieldChange[] = []
-  for (const field of TRACKED_FIELDS) {
-    const before = field.accessor(previous)
-    const after = field.accessor(current)
-    if (before === undefined || after === undefined) continue
-    if (before === after) continue
-
-    const display =
-      field.kind === 'number'
-        ? formatNumberChange(field.label, before as number, after as number)
-        : formatBoolChange(field.label, before as boolean, after as boolean)
-
-    changes.push({ label: field.label, before, after, display })
-  }
-  return changes
+  return map
 }
 
 const byDisplayName = (a: UnitRef, b: UnitRef): number =>
@@ -130,6 +322,7 @@ export function diffFactionVersions(
 ): VersionDiff {
   const prevMap = buildMap(previous)
   const currMap = buildMap(current)
+  const nameMap = buildNameMap(previous, current)
 
   const added: UnitRef[] = []
   const changed: ChangedUnit[] = []
@@ -140,7 +333,9 @@ export function diffFactionVersions(
       added.push(toRef(entry))
       continue
     }
-    const fields = diffUnitFields(prev.unit, entry.unit)
+    const fields: FieldChange[] = []
+    walk(prev.unit, entry.unit, '', fields)
+    diffBuildRelationships(prev.unit, entry.unit, nameMap, fields)
     if (fields.length > 0) {
       changed.push({ ...toRef(entry), fields })
     }

--- a/web/src/utils/versionDiff.ts
+++ b/web/src/utils/versionDiff.ts
@@ -1,0 +1,166 @@
+/**
+ * Computes a human-readable diff between two versions of a faction.
+ *
+ * PA-Pedia has no authored changelog, so "what changed" is derived by comparing
+ * the embedded, fully-resolved unit specs of two faction indexes. Units are keyed
+ * by `identifier`; a curated set of high-signal fields is compared to keep the
+ * resulting list readable.
+ */
+import type { FactionIndex, UnitIndexEntry, Unit } from '@/types/faction'
+import { formatNumber } from '@/utils/groupAggregation'
+
+/** Lightweight reference to a unit, enough to render an icon + link. */
+export interface UnitRef {
+  identifier: string
+  displayName: string
+  image?: string
+}
+
+/** A single changed field on a unit, pre-formatted for display. */
+export interface FieldChange {
+  label: string
+  before: number | boolean | null
+  after: number | boolean | null
+  /** Humanised one-line summary, e.g. "Health: 200 → 250 (+25%)". */
+  display: string
+}
+
+export interface ChangedUnit extends UnitRef {
+  fields: FieldChange[]
+}
+
+export interface VersionDiff {
+  /** The older version being compared from. */
+  fromVersion: string
+  /** The newer version being compared to. */
+  toVersion: string
+  added: UnitRef[]
+  removed: UnitRef[]
+  changed: ChangedUnit[]
+}
+
+type FieldKind = 'number' | 'bool'
+
+interface TrackedField {
+  label: string
+  kind: FieldKind
+  accessor: (unit: Unit) => number | boolean | undefined
+}
+
+/**
+ * High-signal fields compared between versions. Order here is the display order.
+ * Note: `economy.buildCost` is a flat metal cost in the data model (not a
+ * {metal, energy} object), so it is tracked as a single number.
+ */
+const TRACKED_FIELDS: TrackedField[] = [
+  { label: 'Tier', kind: 'number', accessor: (u) => u.tier },
+  { label: 'Accessible', kind: 'bool', accessor: (u) => u.accessible },
+  { label: 'Health', kind: 'number', accessor: (u) => u.specs?.combat?.health },
+  { label: 'DPS', kind: 'number', accessor: (u) => u.specs?.combat?.dps },
+  { label: 'Build cost', kind: 'number', accessor: (u) => u.specs?.economy?.buildCost },
+  { label: 'Build rate', kind: 'number', accessor: (u) => u.specs?.economy?.buildRate },
+  { label: 'Move speed', kind: 'number', accessor: (u) => u.specs?.mobility?.moveSpeed },
+]
+
+function buildMap(index: FactionIndex): Map<string, UnitIndexEntry> {
+  const map = new Map<string, UnitIndexEntry>()
+  for (const entry of index.units) {
+    map.set(entry.identifier, entry)
+  }
+  return map
+}
+
+function toRef(entry: UnitIndexEntry): UnitRef {
+  return {
+    identifier: entry.identifier,
+    displayName: entry.displayName || entry.unit?.displayName || entry.identifier,
+    image: entry.unit?.image,
+  }
+}
+
+function formatNumberChange(label: string, before: number, after: number): string {
+  let display = `${label}: ${formatNumber(before)} → ${formatNumber(after)}`
+  if (before > 0) {
+    const pct = Math.round(((after - before) / before) * 100)
+    if (Math.abs(pct) >= 1) {
+      display += ` (${pct > 0 ? '+' : ''}${pct}%)`
+    }
+  }
+  return display
+}
+
+function formatBoolChange(label: string, before: boolean, after: boolean): string {
+  return `${label}: ${before ? 'Yes' : 'No'} → ${after ? 'Yes' : 'No'}`
+}
+
+/**
+ * Compare the tracked fields of two unit versions. Fields that are absent on
+ * either side are skipped (we can't meaningfully diff a missing value).
+ */
+function diffUnitFields(previous: Unit, current: Unit): FieldChange[] {
+  const changes: FieldChange[] = []
+  for (const field of TRACKED_FIELDS) {
+    const before = field.accessor(previous)
+    const after = field.accessor(current)
+    if (before === undefined || after === undefined) continue
+    if (before === after) continue
+
+    const display =
+      field.kind === 'number'
+        ? formatNumberChange(field.label, before as number, after as number)
+        : formatBoolChange(field.label, before as boolean, after as boolean)
+
+    changes.push({ label: field.label, before, after, display })
+  }
+  return changes
+}
+
+const byDisplayName = (a: UnitRef, b: UnitRef): number =>
+  a.displayName.localeCompare(b.displayName)
+
+/**
+ * Diff two faction versions. `previous` is the older index, `current` the newer.
+ * `fromVersion`/`toVersion` are the human-facing version labels for each.
+ */
+export function diffFactionVersions(
+  previous: FactionIndex,
+  current: FactionIndex,
+  fromVersion: string,
+  toVersion: string
+): VersionDiff {
+  const prevMap = buildMap(previous)
+  const currMap = buildMap(current)
+
+  const added: UnitRef[] = []
+  const changed: ChangedUnit[] = []
+
+  for (const [identifier, entry] of currMap) {
+    const prev = prevMap.get(identifier)
+    if (!prev) {
+      added.push(toRef(entry))
+      continue
+    }
+    const fields = diffUnitFields(prev.unit, entry.unit)
+    if (fields.length > 0) {
+      changed.push({ ...toRef(entry), fields })
+    }
+  }
+
+  const removed: UnitRef[] = []
+  for (const [identifier, entry] of prevMap) {
+    if (!currMap.has(identifier)) {
+      removed.push(toRef(entry))
+    }
+  }
+
+  added.sort(byDisplayName)
+  removed.sort(byDisplayName)
+  changed.sort(byDisplayName)
+
+  return { fromVersion, toVersion, added, removed, changed }
+}
+
+/** True when a diff contains at least one added, removed, or changed unit. */
+export function hasChanges(diff: VersionDiff): boolean {
+  return diff.added.length > 0 || diff.removed.length > 0 || diff.changed.length > 0
+}


### PR DESCRIPTION
## Summary

Adds a **"What changed?"** modal to faction pages. When a faction has multiple published versions, it shows a computed, human-readable diff between the version being viewed and the immediately-previous one — grouped into Added / Changed / Removed units with humanised bullets.

PA-Pedia stores no authored changelog, so the diff is **computed** by comparing the embedded, fully-resolved unit specs of the two versions' indexes. No new data plumbing: it reuses the existing version-keyed faction cache (`factionId@version`), and defers downloading the previous version until the modal is opened.

## How it works

- **`web/src/utils/versionDiff.ts`** — pure diff engine, keyed by unit `identifier`. Walks the **full resolved spec tree** so any meaningful change surfaces (weapon damage/fire rate/range/splash/ammo, economy, mobility, recon, unit types, accessibility, …). Two carve-outs:
  - Internal/derived keys (ids, resource/icon paths, raw `ammoDetails`) are skipped — not player-facing and duplicate resolved values.
  - `buildRelationships` is **summarised** (`Built by: +X −Y`) rather than diffed edge-by-edge, where one new builder unit would otherwise emit hundreds of low-signal bullets.
  - Labels are humanised (`specs.combat.health` → "Health"); weapons are labelled by name, falling back to "Weapon" for internal identifiers.
- **`web/src/components/VersionDiffModal.tsx`** — modal modeled on `BlueprintModal` (backdrop, ESC, close button). Loads the previous version via `useFaction`; computes the diff with `useMemo`.
- **`web/src/pages/FactionDetail.tsx`** — "What changed?" button beside the version selector, shown only for non-local factions when an older version exists.

## Why comprehensive, not key-stats-only

Initially scoped to a handful of stats, but verifying against live Exiles data showed that hid real balance changes: between v0.7.10 and v0.7.20 the only change was Kikimora's weapon (damage 10→45, fire rate 9→2) — a weapon sub-stat, and one aggregate DPS misses entirely (same DPS, repackaged into bigger slower hits). The engine now catches it.

## Testing

- `versionDiff.test.ts` (12) + `VersionDiffModal.test.tsx` (8) — added/removed/changed detection, percentage formatting, boolean/weapon/unit-type/build-relationship rendering, loading/error/empty states, close interactions.
- Full suite: **851 passing**; lint + production build clean.
- Verified end-to-end in-browser against live production data: empty-state, the Kikimora changed-field diff, and unit icons.

## Notes

- The modal always compares **adjacent** versions, so real diffs stay small; the large build-graph churn only appears across very wide gaps the UI never shows.
- Compares current vs immediately-previous only (per design). Weapon `buildableAmmo` lists are intentionally not diffed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)