### PR TITLE
feat(ci): automate 3D model generation (headless Blender workflow)

### DIFF
--- a/.github/workflows/faction-models.yml
+++ b/.github/workflows/faction-models.yml
@@ -59,6 +59,7 @@ jobs:
         env:
           PA_BASE_DATA_KEY: ${{ secrets.PA_BASE_DATA_KEY }}
         run: |
+          set -euo pipefail
           ENC_FILE=$(ls /tmp/base-data-download/pa-base-data-*.tar.gz.enc)
           node -e "
             const crypto = require('crypto');
@@ -114,7 +115,8 @@ jobs:
           # Runtime libs Blender needs to start even in --background.
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            libgl1 libxi6 libxrender1 libxxf86vm1 libxfixes3 libsm6 libxkbcommon0 xz-utils
+            libgl1 libegl1 libxi6 libxrender1 libxxf86vm1 libxfixes3 libsm6 \
+            libxkbcommon0 libxrandr2 libxinerama1 libxcursor1 xz-utils
           MAJOR_MINOR=$(echo "${BLENDER_VERSION}" | cut -d. -f1,2)
           URL="https://download.blender.org/release/Blender${MAJOR_MINOR}/blender-${BLENDER_VERSION}-linux-x64.tar.xz"
           echo "Downloading $URL"

--- a/.github/workflows/faction-models.yml
+++ b/.github/workflows/faction-models.yml
@@ -1,0 +1,175 @@
+name: Faction Models
+
+# Generates 3D model bundles (glb + textures) for factions using headless
+# Blender and publishes them to the `faction-models` release, then regenerates
+# the manifest so the web app shows the "View 3D Model" button.
+#
+# Manual-dispatch only: a full run drives Blender over ~600 units and is heavy,
+# and models change rarely — so this is not on a daily cron (unlike faction data).
+#
+# REQUIREMENTS:
+#   - The `pa-base-data` release archive must include unit .papa files. Re-run
+#     `just extract-base-data` + `just upload-base-data` (with PA_BASE_DATA_KEY)
+#     after the base-data extractor was expanded to include models.
+#   - PA_BASE_DATA_KEY secret (same as update-factions).
+
+on:
+  workflow_dispatch:
+    inputs:
+      profiles:
+        description: 'Comma-separated profile IDs (empty = all)'
+        required: false
+        default: ''
+      texture_size:
+        description: 'Max texture edge in pixels'
+        required: false
+        default: '512'
+
+permissions:
+  contents: write
+
+# Serialise with itself to avoid concurrent release-asset writes.
+concurrency:
+  group: faction-models
+  cancel-in-progress: false
+
+env:
+  BLENDER_VERSION: '5.1.2'
+
+jobs:
+  generate-models:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v7
+
+      # --- PA base data (now includes unit .papa) ---------------------------
+      - name: Download base data
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p /tmp/base-data-download
+          gh release download pa-base-data \
+            --pattern "pa-base-data-*.tar.gz.enc" \
+            --pattern "pa-base-data-meta.json" \
+            --dir /tmp/base-data-download
+          ls -la /tmp/base-data-download/
+
+      - name: Decrypt base data
+        env:
+          PA_BASE_DATA_KEY: ${{ secrets.PA_BASE_DATA_KEY }}
+        run: |
+          ENC_FILE=$(ls /tmp/base-data-download/pa-base-data-*.tar.gz.enc)
+          node -e "
+            const crypto = require('crypto');
+            const fs = require('fs');
+            const data = fs.readFileSync('$ENC_FILE');
+            const iv = data.subarray(0, 16);
+            const encrypted = data.subarray(16);
+            const key = crypto.scryptSync(process.env.PA_BASE_DATA_KEY, 'pa-pedia-base-data', 32);
+            const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
+            const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+            fs.writeFileSync('/tmp/pa-base-data.tar.gz', decrypted);
+          "
+          mkdir -p /tmp/pa-media
+          tar -xzf /tmp/pa-base-data.tar.gz -C /tmp/pa-media
+          echo "Unit .papa files in base data:"
+          find /tmp/pa-media -path '*/units/*' -name '*.papa' | wc -l
+
+      - name: Fail early if base data has no models
+        run: |
+          COUNT=$(find /tmp/pa-media -path '*/units/*' -name '*.papa' | wc -l)
+          if [ "$COUNT" -eq 0 ]; then
+            echo "::error::The pa-base-data archive contains no unit .papa files."
+            echo "Re-run 'just extract-base-data' + 'just upload-base-data' after the"
+            echo "extractor was expanded to include models, then re-run this workflow."
+            exit 1
+          fi
+
+      # --- Toolchain --------------------------------------------------------
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: cli/go.mod
+          cache-dependency-path: cli/go.sum
+
+      - name: Build CLI
+        working-directory: cli
+        run: go build -o /tmp/pa-pedia .
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: scripts/package-lock.json
+
+      - name: Install script dependencies
+        working-directory: scripts
+        run: npm ci
+
+      # --- Headless Blender (pinned; addon validated on 5.1.x) --------------
+      - name: Install Blender ${{ env.BLENDER_VERSION }}
+        run: |
+          set -euo pipefail
+          # Runtime libs Blender needs to start even in --background.
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libgl1 libxi6 libxrender1 libxxf86vm1 libxfixes3 libsm6 libxkbcommon0 xz-utils
+          MAJOR_MINOR=$(echo "${BLENDER_VERSION}" | cut -d. -f1,2)
+          URL="https://download.blender.org/release/Blender${MAJOR_MINOR}/blender-${BLENDER_VERSION}-linux-x64.tar.xz"
+          echo "Downloading $URL"
+          curl -fsSL "$URL" -o /tmp/blender.tar.xz
+          mkdir -p /tmp/blender
+          tar -xJf /tmp/blender.tar.xz -C /tmp/blender --strip-components=1
+          echo "BLENDER_BIN=/tmp/blender/blender" >> "$GITHUB_ENV"
+          /tmp/blender/blender --version
+
+      # --- Generate models --------------------------------------------------
+      - name: Determine profiles
+        id: profiles
+        run: |
+          INPUT="${{ github.event.inputs.profiles }}"
+          if [ -z "$INPUT" ]; then
+            echo "profiles=mla legion exiles bugs second-wave" >> "$GITHUB_OUTPUT"
+          else
+            echo "profiles=$(echo "$INPUT" | tr ',' ' ')" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract models
+        run: |
+          set -euo pipefail
+          for profile in ${{ steps.profiles.outputs.profiles }}; do
+            echo "==================== $profile ===================="
+            /tmp/pa-pedia extract-models \
+              --profile "$profile" \
+              --pa-root /tmp/pa-media \
+              --output ./models \
+              --blender "$BLENDER_BIN" \
+              --texture-size "${{ github.event.inputs.texture_size || '512' }}"
+          done
+
+      - name: Build model bundles
+        working-directory: scripts
+        run: npm run build:model-bundles
+
+      - name: Upload model bundles to release
+        working-directory: scripts
+        run: npm run upload:model-bundles
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Regenerate the manifest so version entries gain their `models` field
+      # (and the web app starts showing the 3D button).
+      - name: Regenerate manifest
+        working-directory: scripts
+        run: npm run generate:manifest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload build artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: model-bundles
+          path: models/dist/
+          retention-days: 7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,6 +387,31 @@ just upload-base-data
 
 The base data is stored as an encrypted release asset on the `pa-base-data` tag. Only the CI pipeline can decrypt it.
 
+**Note**: The base data archive includes unit `.papa` model/texture files (under `units/`) so the Faction Models workflow can generate 3D models in CI. This makes the archive larger (~180 MB) — re-run `just extract-base-data` + `just upload-base-data` after any change to the extractor's include rules.
+
+### 3D Model Generation
+
+**GitHub Actions Workflow** (`.github/workflows/faction-models.yml`):
+
+Manual-dispatch only (`workflow_dispatch`) — a full run drives headless Blender over ~600 units and is heavy, and models change rarely (so it is not a daily cron).
+
+**How it works**:
+1. Downloads + decrypts the `pa-base-data` archive (must include unit `.papa` — see note above)
+2. Installs pinned headless Blender (`BLENDER_VERSION`, 5.1.x validated)
+3. Builds the CLI, runs `extract-models` per profile → `models/{Faction}/`
+4. `build-model-bundles` zips them → `models/dist/{id}-{version}-pedia{ts}-models.zip`
+5. Uploads bundles to the **`faction-models`** release (separate from `faction-data`)
+6. Regenerates the manifest so version entries gain their `models` field → the web app shows the "View 3D Model" button
+
+**Local generation** (needs a PA install + Blender 5.1.x on PATH):
+```bash
+just generate-models        # extract-models for all profiles → ./models
+just build-model-bundles    # zip → ./models/dist
+# then publish: npm --prefix scripts run upload:model-bundles && npm --prefix scripts run generate:manifest
+```
+
+The feature is invisible until model bundles exist on the `faction-models` release — merging the web/CLI code alone does not show 3D buttons.
+
 ## Common Development Tasks
 
 ### Add New Unit Field

--- a/scripts/extract-base-data.ts
+++ b/scripts/extract-base-data.ts
@@ -5,6 +5,7 @@
  * - JSON specs (units, ammo, tools, base specs)
  * - Buildbar icons (*_icon_buildbar.png)
  * - Background/splash images referenced by profiles
+ * - Unit model/texture .papa files under units/ (for CI 3D model generation)
  *
  * Creates a tar.gz archive, then encrypts it with AES-256-CBC for safe storage
  * as a public GitHub release asset.
@@ -33,11 +34,20 @@ const ADDITIONAL_PATTERNS = [
   /^ui\/.*\.(png|jpg)$/, // UI images (splash screens, backgrounds)
 ]
 
+/**
+ * Unit model + texture .papa files, needed by `extract-models` to build the 3D
+ * model bundles in CI. Scoped to `units/` (base + expansion) so we pull unit
+ * meshes/textures/animations (~180 MB) rather than the whole ~1.1 GB of .papa in
+ * the media tree (effects, environment, etc.). Paths are normalised to `/`.
+ */
+const MODEL_PATTERNS = [/(^|\/)units\/.*\.papa$/]
+
 interface ExtractStats {
   totalFiles: number
   totalSize: number
   jsonFiles: number
   pngFiles: number
+  papaFiles: number
   otherFiles: number
 }
 
@@ -55,9 +65,19 @@ function shouldIncludeFile(relativePath: string): boolean {
     if (pattern.test(relativePath)) return true
   }
 
+  const normalized = relativePath.replace(/\\/g, '/')
+
   // Include UI assets (splash screens referenced by profiles)
   for (const pattern of ADDITIONAL_PATTERNS) {
-    if (pattern.test(relativePath.replace(/\\/g, '/'))) return true
+    if (pattern.test(normalized)) return true
+  }
+
+  // Include unit model/texture .papa files (for CI 3D model generation)
+  if (ext === '.papa') {
+    for (const pattern of MODEL_PATTERNS) {
+      if (pattern.test(normalized)) return true
+    }
+    return false
   }
 
   return false
@@ -269,7 +289,7 @@ async function main() {
   console.log()
 
   // Calculate stats
-  const stats: ExtractStats = { totalFiles: files.length, totalSize: 0, jsonFiles: 0, pngFiles: 0, otherFiles: 0 }
+  const stats: ExtractStats = { totalFiles: files.length, totalSize: 0, jsonFiles: 0, pngFiles: 0, papaFiles: 0, otherFiles: 0 }
   for (const file of files) {
     const fullPath = path.join(paRoot, file)
     const fileStat = fs.statSync(fullPath)
@@ -277,12 +297,14 @@ async function main() {
     const ext = path.extname(file).toLowerCase()
     if (ext === '.json') stats.jsonFiles++
     else if (ext === '.png') stats.pngFiles++
+    else if (ext === '.papa') stats.papaFiles++
     else stats.otherFiles++
   }
 
   console.log(`Stats:`)
   console.log(`  JSON files: ${stats.jsonFiles}`)
   console.log(`  PNG files:  ${stats.pngFiles}`)
+  console.log(`  PAPA files: ${stats.papaFiles}`)
   console.log(`  Other:      ${stats.otherFiles}`)
   console.log(`  Total size: ${(stats.totalSize / 1024 / 1024).toFixed(2)} MB (uncompressed)`)
   console.log()
@@ -367,6 +389,7 @@ async function main() {
       totalSizeBytes: stats.totalSize,
       jsonFiles: stats.jsonFiles,
       pngFiles: stats.pngFiles,
+      papaFiles: stats.papaFiles,
     },
     sha256Unencrypted: tarHash,
     extractedAt: now.toISOString(),

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -7,6 +7,7 @@
     "test": "node --import tsx --test manifest-ordering.test.ts",
     "build:zips": "tsx build-faction-zips.ts",
     "build:model-bundles": "tsx build-model-bundles.ts",
+    "upload:model-bundles": "tsx upload-model-bundles.ts",
     "upload:releases": "tsx upload-to-releases.ts",
     "generate:manifest": "tsx generate-manifest.ts",
     "release": "npm run build:zips && npm run upload:releases && npm run generate:manifest",

--- a/scripts/upload-model-bundles.ts
+++ b/scripts/upload-model-bundles.ts
@@ -91,7 +91,10 @@ function uploadZip(filename: string): void {
     throw new Error(`Model bundle not found: ${zipPath}`)
   }
   console.log(`Uploading ${filename}...`)
-  exec(`gh release upload ${RELEASE_TAG} "${zipPath}" --clobber`)
+  // Use raw execSync (not the error-swallowing exec wrapper): a failed upload
+  // MUST fail the step, otherwise the manifest regen finds no bundle and the 3D
+  // button silently never appears.
+  execSync(`gh release upload ${RELEASE_TAG} "${zipPath}" --clobber`, { stdio: 'inherit' })
 }
 
 async function main() {

--- a/scripts/upload-model-bundles.ts
+++ b/scripts/upload-model-bundles.ts
@@ -1,0 +1,131 @@
+/**
+ * Upload faction model bundles to the `faction-models` GitHub Release.
+ *
+ * Mirrors upload-to-releases.ts but targets a SEPARATE release tag so the heavy
+ * model bundles never interfere with the fast `faction-data` (spec zip) release.
+ * Reads models/dist/model-build-summary.json (written by build-model-bundles.ts)
+ * and uploads each `{id}-{version}-pedia{ts}-models.zip`, deleting older
+ * timestamps of the same faction+version (different versions are preserved).
+ *
+ * Prerequisites: GitHub CLI (gh) authenticated (GITHUB_TOKEN in CI).
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { execSync } from 'node:child_process'
+
+const MODELS_DIR = path.join(import.meta.dirname, '..', 'models')
+const OUTPUT_DIR = path.join(MODELS_DIR, 'dist')
+const RELEASE_TAG = 'faction-models'
+
+interface ModelBuildSummary {
+  timestamp: string
+  bundles: { factionId: string; filename: string; version: string; unitCount: number }[]
+}
+
+function checkGhCli(): void {
+  try {
+    execSync('gh --version', { stdio: 'pipe' })
+  } catch {
+    console.error('Error: GitHub CLI (gh) is not installed or not in PATH')
+    process.exit(1)
+  }
+}
+
+function exec(command: string, options?: { silent?: boolean }): string {
+  if (!options?.silent) console.log(`$ ${command}`)
+  try {
+    return execSync(command, { encoding: 'utf-8', stdio: options?.silent ? 'pipe' : 'inherit' })
+  } catch (error) {
+    if (error instanceof Error && 'stdout' in error) {
+      return (error as { stdout: string }).stdout || ''
+    }
+    throw error
+  }
+}
+
+function releaseExists(): boolean {
+  try {
+    execSync(`gh release view ${RELEASE_TAG}`, { stdio: 'pipe' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function ensureReleaseExists(): void {
+  if (releaseExists()) {
+    console.log(`Release '${RELEASE_TAG}' already exists`)
+    return
+  }
+  console.log(`Creating release '${RELEASE_TAG}'...`)
+  exec(
+    `gh release create ${RELEASE_TAG} --title "Faction Models" --notes "Auto-generated 3D model bundles (glb + textures) for PA-Pedia. Updated by the Faction Models workflow."`
+  )
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/** Delete older timestamps of the same faction+version (preserve other versions). */
+function deleteSameVersionDuplicates(factionId: string, version: string, newFilename: string): void {
+  const output = execSync(`gh release view ${RELEASE_TAG} --json assets -q ".assets[].name"`, {
+    encoding: 'utf-8',
+  })
+  const assets = output.trim().split('\n').filter(Boolean)
+  const sameVersionPattern = new RegExp(
+    `^${escapeRegex(factionId)}-${escapeRegex(version)}-pedia\\d{14}-models\\.zip$`,
+    'i'
+  )
+  const duplicates = assets.filter((name) => sameVersionPattern.test(name) && name !== newFilename)
+  for (const asset of duplicates) {
+    console.log(`  Deleting older timestamp: ${asset}`)
+    exec(`gh release delete-asset ${RELEASE_TAG} "${asset}" --yes`, { silent: true })
+  }
+}
+
+function uploadZip(filename: string): void {
+  const zipPath = path.join(OUTPUT_DIR, filename)
+  if (!fs.existsSync(zipPath)) {
+    throw new Error(`Model bundle not found: ${zipPath}`)
+  }
+  console.log(`Uploading ${filename}...`)
+  exec(`gh release upload ${RELEASE_TAG} "${zipPath}" --clobber`)
+}
+
+async function main() {
+  console.log('Uploading model bundles to GitHub Releases...')
+  console.log(`Release tag: ${RELEASE_TAG}`)
+  console.log()
+
+  checkGhCli()
+
+  const summaryPath = path.join(OUTPUT_DIR, 'model-build-summary.json')
+  if (!fs.existsSync(summaryPath)) {
+    console.error('Model build summary not found. Run build:model-bundles first.')
+    process.exit(1)
+  }
+
+  const summary: ModelBuildSummary = JSON.parse(fs.readFileSync(summaryPath, 'utf-8'))
+  console.log(`Build timestamp: ${summary.timestamp}`)
+  console.log(`Bundles to upload: ${summary.bundles.length}`)
+  console.log()
+
+  ensureReleaseExists()
+  console.log()
+
+  for (const bundle of summary.bundles) {
+    console.log(`Processing ${bundle.factionId} v${bundle.version} (${bundle.unitCount} units)...`)
+    deleteSameVersionDuplicates(bundle.factionId, bundle.version, bundle.filename)
+    uploadZip(bundle.filename)
+    console.log()
+  }
+
+  console.log('Model bundle upload complete!')
+}
+
+main().catch((error) => {
+  console.error('Upload failed:', error)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

Automates 3D model generation in CI so the feature can go live (and stay updated) without a manual local Blender pass — the follow-up you asked for after #406/#407.

Adds `.github/workflows/faction-models.yml` (**manual `workflow_dispatch` only** — a full run drives headless Blender over ~600 units and is heavy; models change rarely, so it's not a daily cron).

## How it works
1. Downloads + decrypts the `pa-base-data` archive (now including unit `.papa`)
2. Installs pinned headless Blender (`BLENDER_VERSION=5.1.2`, the validated version)
3. Builds the CLI, runs `extract-models` per profile → `models/{Faction}/`
4. `build-model-bundles` zips them; `upload-model-bundles` publishes to the **`faction-models`** release (separate from `faction-data`)
5. Regenerates the manifest → version entries gain their `models` field → the web app shows the "View 3D Model" button

## Also
- **`extract-base-data` now includes unit `.papa`** (geometry + textures under `units/`, ~180 MB) so CI has meshes to convert. Scoped to `units/` (not the full ~1.1 GB of `.papa` in the media tree). Verified the include/exclude logic against the real install.
- New `scripts/upload-model-bundles.ts` (+ `upload:model-bundles`), parallel to the faction-data uploader.
- Docs updated (base-data note + workflow section).

## ⚠️ One manual step required before this can run
The `pa-base-data` release must be **re-published with the expanded (`.papa`-including) archive** — run `just extract-base-data` + `just upload-base-data` locally with `PA_BASE_DATA_KEY` (I can't; the key is yours). The workflow **fails fast with a clear message** if the base data has no unit `.papa`. After the re-upload, dispatch the workflow to turn on 3D models.

## Verification notes
- YAML validated; `scripts` tsc + tests pass; extract-base-data include logic unit-checked against the real PA install.
- The end-to-end CI run itself can't be exercised until the base data is re-published (above); `extract-models` → `build-model-bundles` was already validated locally on real MLA data in #406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
