### PR TITLE
fix(scripts): mkdir manifest output dir (faction-models workflow)

### DIFF
--- a/scripts/generate-manifest.ts
+++ b/scripts/generate-manifest.ts
@@ -367,8 +367,11 @@ async function main() {
     factions: factionEntries,
   }
 
-  // Write manifest to file
+  // Write manifest to file. Ensure the output dir exists — the faction-data
+  // workflow creates it via build:zips first, but the faction-models workflow
+  // calls this directly, so don't assume it's present.
   const manifestPath = path.join(OUTPUT_DIR, 'manifest.json')
+  fs.mkdirSync(OUTPUT_DIR, { recursive: true })
   fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2))
   console.log()
   console.log(`Manifest written to ${manifestPath}`)


### PR DESCRIPTION
## Summary
The **Faction Models** workflow (#409) failed at "Regenerate manifest" with `ENOENT` writing `factions/dist/manifest.json` — that workflow calls `generate:manifest` directly, without the `build:zips` step that the faction-data workflow uses to create `factions/dist/`. So the models were generated + uploaded, but the manifest never updated.

Fix: `generate-manifest` now `mkdir -p`s its output dir before writing.

## Context
Recovered the live manifest manually (ran generate:manifest locally) so the feature is already live; this makes the automated workflow correct for future runs.

Trivial one-line robustness fix, verified by the CI failure log + local run. tsc + scripts tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)