### PR TITLE
feat: serve model bundles via Pages Function proxy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'web/**'
       - 'schema/**'
+      - 'functions/**'
   # Also deploy when faction data is updated by the faction workflow
   workflow_run:
     workflows: ["Faction Data Release"]

--- a/functions/faction-models/[[path]].js
+++ b/functions/faction-models/[[path]].js
@@ -55,8 +55,14 @@ export async function onRequest(context) {
     const v = upstream.headers.get(h)
     if (v) headers.set(h, v)
   }
-  // Bundle filenames are timestamped (immutable), so cache aggressively.
-  headers.set('cache-control', 'public, max-age=86400')
+  // Cache only successful responses — bundle filenames are timestamped
+  // (immutable). Never cache errors (a transient 404/5xx or a not-yet-uploaded
+  // bundle must not be cached as broken for a day).
+  if (upstream.ok || upstream.status === 206) {
+    headers.set('cache-control', 'public, max-age=86400')
+  } else {
+    headers.set('cache-control', 'no-store')
+  }
 
   return new Response(request.method === 'HEAD' ? null : upstream.body, {
     status: upstream.status,

--- a/functions/faction-models/[[path]].js
+++ b/functions/faction-models/[[path]].js
@@ -1,0 +1,66 @@
+/**
+ * Cloudflare Pages Function: proxy /faction-models/* to the GitHub `faction-models`
+ * release, same-origin.
+ *
+ * Model bundles are 20-80 MB — too large to bake into the Pages deploy (25 MB
+ * per-file limit), and GitHub release assets send no CORS headers, so the
+ * browser can't fetch them cross-origin. This Function streams them from the
+ * release server-side (same-origin → no CORS) and forwards HTTP Range so the
+ * web app's per-unit range reads into the bundles keep working.
+ */
+
+const RELEASE_BASE =
+  'https://github.com/jamiemulcahy/pa-pedia/releases/download/faction-models/'
+
+export async function onRequest(context) {
+  const { request, params } = context
+
+  // Catch-all param: filename segment(s) after /faction-models/.
+  const segs = Array.isArray(params.path) ? params.path : [params.path]
+  const file = segs.join('/')
+  if (!file) {
+    return new Response('Not found', { status: 404 })
+  }
+
+  // Only GET/HEAD make sense for asset delivery.
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    return new Response('Method not allowed', { status: 405 })
+  }
+
+  const target = RELEASE_BASE + encodeURIComponent(file)
+
+  // Forward only Range (and If-Range) — never cookies/auth to a public asset.
+  const fwd = {}
+  const range = request.headers.get('Range')
+  if (range) fwd['Range'] = range
+  const ifRange = request.headers.get('If-Range')
+  if (ifRange) fwd['If-Range'] = ifRange
+
+  const upstream = await fetch(target, {
+    method: request.method,
+    headers: fwd,
+    redirect: 'follow',
+  })
+
+  // Copy through the headers the web client relies on for range + caching.
+  const headers = new Headers()
+  for (const h of [
+    'content-type',
+    'content-length',
+    'content-range',
+    'accept-ranges',
+    'etag',
+    'last-modified',
+  ]) {
+    const v = upstream.headers.get(h)
+    if (v) headers.set(h, v)
+  }
+  // Bundle filenames are timestamped (immutable), so cache aggressively.
+  headers.set('cache-control', 'public, max-age=86400')
+
+  return new Response(request.method === 'HEAD' ? null : upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers,
+  })
+}


### PR DESCRIPTION
## Summary
Fixes why 3D model buttons don't appear on the live site.

**Root cause:** the site serves faction data as static files baked into the Cloudflare Pages deploy (see deploy.yml comment: same-origin to avoid CORS). But Pages has a **25 MB per-file limit** and model bundles are 20–84 MB, so they can't be baked in. The web fetches them from `pa-pedia.com/faction-models/*`, which didn't exist. GitHub release assets support Range (206) but send **no CORS headers**, so a direct browser fetch is cross-origin-blocked.

**Fix:** a Cloudflare Pages Function (`functions/faction-models/[[path]].js`) proxies `/faction-models/*` to the `faction-models` GitHub release **server-side** (same-origin → no CORS), forwarding HTTP `Range`/`If-Range` so the web app's per-unit range reads into the bundles keep working. No 300 MB baked into the deploy — the Function streams from the release on demand.

## Also
- deploy triggers on `functions/**` changes.
- A redeploy (which this triggers) also refreshes the stale baked `manifest.json` from the release (which now advertises models), fixing the second reason buttons weren't showing.

## Security
Host is hardcoded to the release base; filename is `encodeURIComponent`-escaped (no path traversal / SSRF); only `Range`/`If-Range` forwarded (no cookies/auth); GET/HEAD only.

## Verification
Function JS syntax-checked; deploy YAML validated. The proxy can only be fully verified once deployed — I'll confirm `/faction-models/*` returns 206 same-origin and that buttons render live right after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)