### PR TITLE
fix: proxy must advertise Accept-Ranges so the 3D button shows

### DIFF
--- a/functions/faction-models/[[path]].js
+++ b/functions/faction-models/[[path]].js
@@ -60,6 +60,12 @@ export async function onRequest(context) {
   // bundle must not be cached as broken for a day).
   if (upstream.ok || upstream.status === 206) {
     headers.set('cache-control', 'public, max-age=86400')
+    // Always advertise range support. Both this proxy and the release backend
+    // honour Range (verified 206), but GitHub's CDN omits Accept-Ranges on the
+    // 206/HEAD responses — and zip.js (the web client) treats a missing
+    // Accept-Ranges as "no range support" and refuses to do range reads, which
+    // would hide the 3D viewer. Setting it here keeps the per-unit range reads.
+    headers.set('accept-ranges', 'bytes')
   } else {
     headers.set('cache-control', 'no-store')
   }


### PR DESCRIPTION
## Root cause (diagnosed live via the browser)
The 3D "View Model" button never appeared because the web app's `models.json` range-read failed. In the browser, a range GET to `/faction-models/*` returns a correct **206 + Content-Range**, but **`Accept-Ranges` is absent** (GitHub's CDN omits it on 206/HEAD, and the proxy only forwarded it when present). zip.js's `HttpRangeReader` treats a missing `Accept-Ranges` as "range not supported" → throws `RangeUnsupportedError` → the range-only availability precheck (which by design does NOT fall back to a whole-bundle download on page load) returns null → the button is hidden.

Console confirmed:
> Model bundle range requests unsupported; using whole-bundle fallback
> Model index unavailable without a whole-bundle download; hiding 3D viewer

## Fix
The proxy now always sets `Accept-Ranges: bytes` on success responses (200/206). Both the proxy and the release backend genuinely support Range (verified 206 for head+tail), so advertising it is correct — it just needs to be present for zip.js to use range reads.

One-line fix, verified against the live site; I'll confirm the button renders after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)