### PR TITLE
fix(web): force range requests so 3D viewer works behind the proxy

### DIFF
--- a/web/src/services/modelLoader.ts
+++ b/web/src/services/modelLoader.ts
@@ -194,7 +194,13 @@ async function extractViaRange(
   // GitHub release and serves correct 206 Partial Content, but Cloudflare strips
   // Accept-Ranges from the 206 responses, which would otherwise make zip.js
   // throw "HTTP Range not supported" and hide the 3D viewer.
-  const reader = new ZipReader(new HttpRangeReader(url, { forceRangeRequests: true }))
+  // Cast: forceRangeRequests is supported at runtime but missing from the
+  // installed zip.js type defs.
+  const reader = new ZipReader(
+    new HttpRangeReader(url, {
+      forceRangeRequests: true,
+    } as ConstructorParameters<typeof HttpRangeReader>[1])
+  )
   let entries: Entry[]
   // Reading the central directory is the range-dependent step; a failure here
   // means Range is unsupported. Entry reads below are NOT treated as range

--- a/web/src/services/modelLoader.ts
+++ b/web/src/services/modelLoader.ts
@@ -189,7 +189,12 @@ async function extractViaRange(
   url: string,
   names: string[]
 ): Promise<Map<string, Uint8Array>> {
-  const reader = new ZipReader(new HttpRangeReader(url))
+  // forceRangeRequests: skip zip.js's Accept-Ranges probe and just issue range
+  // requests. Our Cloudflare Pages Function proxies model bundles from the
+  // GitHub release and serves correct 206 Partial Content, but Cloudflare strips
+  // Accept-Ranges from the 206 responses, which would otherwise make zip.js
+  // throw "HTTP Range not supported" and hide the 3D viewer.
+  const reader = new ZipReader(new HttpRangeReader(url, { forceRangeRequests: true }))
   let entries: Entry[]
   // Reading the central directory is the range-dependent step; a failure here
   // means Range is unsupported. Entry reads below are NOT treated as range


### PR DESCRIPTION
## Root cause (diagnosed live with the real library)
The 3D button stayed hidden because zip.js's `HttpRangeReader` hard-requires an `Accept-Ranges: bytes` header on its probe (`dist/zip-core.js:2756`) or throws `HTTP Range not supported`:
```js
const acceptRanges = response.headers.get("Accept-Ranges");
if (!forceRangeRequests && (!acceptRanges || acceptRanges.toLowerCase() != "bytes")) throw new Error(ERR_HTTP_RANGE);
```
The Pages Function proxy serves **correct 206 range responses**, but **Cloudflare strips `Accept-Ranges` from 206s** (it's present on 200/HEAD, gone on 206), and I couldn't reliably force it back on. So the range-only availability precheck threw and hid the viewer.

## Fix
Pass `{ forceRangeRequests: true }` to `HttpRangeReader`, so zip.js skips the `Accept-Ranges` probe and issues range requests directly — which the proxy serves correctly.

## Verified against the LIVE proxy (real zip.js)
`getEntries()` → 751 entries, reads `models.json` (unitCount 187, correct unit keys). tsc + eslint + all 10 modelLoader tests pass. I'll confirm the button renders in the browser after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)