### PR TITLE
fix(3d): recover Blender-5.x model conversion + kill viewer flicker

### DIFF
--- a/cli/pkg/models3d/blender-papa-io/import_papa.py
+++ b/cli/pkg/models3d/blender-papa-io/import_papa.py
@@ -127,6 +127,18 @@ def load_papa(properties, context):
                     normals = []
                     for i in range(vBuffer.getNumVertices()):
                         normals.append(vBuffer.getVertex(i).getNormal())
+                    # Blender 4.1+/5.x: normals_split_custom_set_from_vertices()
+                    # reads per-corner normal storage that Blender leaves
+                    # uninitialised for degenerate (zero-area) faces, so the
+                    # native call segfaults (EXCEPTION_ACCESS_VIOLATION) on any
+                    # mesh that contains one — e.g. several PA unit meshes such as
+                    # Dox. validate() strips those invalid faces first, fixing the
+                    # crash; on a clean mesh it is a no-op. Removing faces can
+                    # shift polygon indices, but the glb is exported with
+                    # materials=NONE so the material groups assigned below never
+                    # reach the output (the bounds guard there just keeps the
+                    # assignment from raising on the now-shorter polygon list).
+                    blenderMesh.data.validate(verbose=False)
                     blenderMesh.data.normals_split_custom_set_from_vertices(normals)
 
                 # create the material groups
@@ -150,8 +162,14 @@ def load_papa(properties, context):
                         continue
 
                     ind = materialMap[material]
+                    polyCount = len(blenderMesh.data.polygons)
                     for i in range(mat.getFirstIndex()//3, mat.getFirstIndex()//3 + mat.getNumPrimitives()):
-                        blenderMesh.data.polygons[i].material_index = ind
+                        # validate() (see importNormals above) may have removed
+                        # degenerate faces, shortening the polygon list; skip any
+                        # index past the end. Harmless: the glb exports with
+                        # materials=NONE, so these assignments are display-only.
+                        if i < polyCount:
+                            blenderMesh.data.polygons[i].material_index = ind
                 
                 if papaFile.getNumTextures() > 0: # textures in the file itself, try to find them
                     for i in range(mesh.getNumMaterialGroups()):
@@ -358,6 +376,20 @@ def load_papa(properties, context):
         
         animTargetArmature.animation_data.action = action # link to action
 
+        # Blender 4.4+ (incl. 5.x) replaced the legacy Action.groups /
+        # Action.fcurves collections with "slotted" actions, where f-curves live
+        # on a channelbag inside a layer strip, addressed by the slot the id is
+        # animated with. Resolve the right channel container so the group/fcurve
+        # creation below works on both old (< 4.4) and new Blender.
+        if hasattr(action, "groups"):
+            channels = action  # legacy Blender: Action.groups / Action.fcurves
+        else:
+            slot = action.slots.new(id_type='OBJECT', name=animTargetArmature.name)
+            animTargetArmature.animation_data.action_slot = slot
+            layer = action.layers.new("Layer")
+            strip = layer.strips.new(type='KEYFRAME')
+            channels = strip.channelbag(slot, ensure=True)
+
         # correct each bone to a format that blender accepts
         for bone in animTargetArmature.pose.bones:
             processBone(bone, animation)
@@ -370,17 +402,17 @@ def load_papa(properties, context):
             except KeyError:
                 continue # we allow some misses with fuzzy
             
-            group = action.groups.new(name=currentBone.getName())
+            group = channels.groups.new(name=currentBone.getName())
             boneString = "pose.bones[\""+currentBone.getName()+"\"]."
             curvesLoc = []
             curvesRot = []
-            
+
             for i in range(3): # set up groups for location
-                curve = action.fcurves.new(data_path=boneString + "location",index=i)
+                curve = channels.fcurves.new(data_path=boneString + "location",index=i)
                 curve.group = group
                 curvesLoc.append(curve)
             for i in range(4): # set up groups for rotation
-                curve = action.fcurves.new(data_path=boneString + "rotation_quaternion",index=i)
+                curve = channels.fcurves.new(data_path=boneString + "rotation_quaternion",index=i)
                 curve.group = group
                 curvesRot.append(curve)
 

--- a/web/src/components/UnitModelViewer.tsx
+++ b/web/src/components/UnitModelViewer.tsx
@@ -248,6 +248,10 @@ export function UnitModelViewer({
       scene.add(keyLight)
 
       const grid = new THREE.GridHelper(20, 20, 0x334155, 0x1e293b)
+      // Sit the grid a hair below y=0 so it never lands exactly coplanar with a
+      // model's flat underside (structures rest their base on y=0), which would
+      // otherwise z-fight into a shimmer as the model auto-rotates. The offset is
+      // scaled to the model below, once we know its size.
       scene.add(grid)
       disposables.push(grid.geometry, grid.material as THREE.Material)
 
@@ -348,6 +352,17 @@ export function UnitModelViewer({
       obj.position.y += size.y / 2
       const r = Math.max(size.x, size.y, size.z) || 1
       camera.position.set(r * 1.6, r * 1.3, r * 1.9)
+      // Tighten the depth range to the model's actual size. The default
+      // 0.1 → 1000 span wastes almost all depth-buffer precision on empty space
+      // in front of PA-scale models, so their many near-coplanar armour panels
+      // z-fight into a heavy flicker while auto-rotating. A near:far ratio of a
+      // few thousand keeps the depth buffer precise across the whole model.
+      camera.near = r * 0.05
+      camera.far = r * 100
+      camera.updateProjectionMatrix()
+      // Drop the grid just beneath the model's base so the two are never exactly
+      // coplanar (see grid creation above).
+      grid.position.y = -r * 0.002
       controls.target.set(0, size.y / 2, 0)
       controls.update()
       scene.add(obj)


### PR DESCRIPTION
## Why

Investigating a report that a unit's 3D model wasn't appearing, I found the viewer itself works, but **Dox (`assault_bot`)** — one of the most iconic PA units — and a couple of others have no model because they **crash headless Blender during conversion** and get silently skipped. Separately, the Air Factory model **flickers heavily while auto-rotating**. This PR fixes all of it.

## What

**1. Native Blender crash on degenerate-face meshes** (Dox, `tank_light_laser`, `titan_bot`, and Legion's crashers)
`normals_split_custom_set_from_vertices()` null-derefs in Blender 4.1+/5.x on zero-area faces, crashing the whole process (`EXCEPTION_ACCESS_VIOLATION`). The resilient runner then isolates and skips the unit → no `models.json` entry → no "View 3D Model" button. Fix: `mesh.validate()` strips the invalid faces first (a no-op on clean meshes); the material-group loop is bounds-guarded since `validate()` can shorten the polygon list (harmless — the glb exports `materials=NONE`).

**2. `action.groups` AttributeError on animated model imports** (Exiles, Second Wave "Failed conversion")
Blender 4.4+/5.x replaced legacy `Action.groups`/`Action.fcurves` with slotted actions. The import now resolves a channel container that works on both old and new Blender.

**3. Viewer z-fighting flicker** (`UnitModelViewer.tsx`)
Camera `near/far` was a fixed `0.1/1000`; PA models are large (Air Factory `r≈30`, camera ~57 away), so depth precision was wasted and coplanar armour panels z-fought into a shimmer while rotating. Now scaled to the model (`near=r*0.05`, `far=r*100`), and the grid sits just off the base plane.

## Verification

Reproduced and verified against installed **Blender 5.1.2** + a local PA install:
- The three previously-crashing units now convert; `air_factory`/`radar` unregressed.
- Animation import that previously errored now succeeds.
- Flicker gone — confirmed with an A/B at an identical static angle and quantitative near/far analysis; Dox renders correctly in the viewer.
- `tsc`, `eslint`, model `vitest` (17), and `go test ./pkg/models3d` all green.

## Follow-up

The fixes are faction-agnostic. After merge, re-dispatch the **Faction Models** workflow to regenerate all 5 factions so the recovered units (Dox et al.) get bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKbnTD3a4ozzimdY6i8UjJ