### PR TITLE
fix(ci): never prune infra releases in CLI release cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,12 +146,27 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Keep only the 10 most recent releases, delete older ones
+          # Keep only the 10 most recent VERSIONED (CLI binary) releases, deleting
+          # older ones. Infrastructure releases are NEVER pruned: they hold the
+          # faction data + manifest, 3D model bundles and the encrypted PA base
+          # data, and deploy.yml downloads faction data + manifest from
+          # `faction-data` on every deploy — deleting it silently wipes the live
+          # site's factions on the next deploy. (gh release list is not ordered by
+          # publish date, so these infra releases could otherwise fall outside the
+          # "10 most recent" window and be pruned, as `faction-data` was.)
+          PROTECTED="latest faction-data faction-models pa-base-data"
+
           echo "Fetching releases..."
           RELEASES=$(gh release list --json tagName --jq '.[].tagName')
 
           COUNT=0
           for TAG in $RELEASES; do
+            case " $PROTECTED " in
+              *" $TAG "*)
+                echo "Keeping protected release: $TAG"
+                continue
+                ;;
+            esac
             COUNT=$((COUNT + 1))
             if [ $COUNT -gt 10 ]; then
               echo "Deleting old release: $TAG"


### PR DESCRIPTION
## Problem (production-impacting)

`release.yml`'s **Cleanup old releases** step keeps the 10 most recent releases and deletes the rest with `--cleanup-tag`. But `gh release list` is **not ordered by publish date**, so the infrastructure releases can fall outside the "10 most recent" window and get pruned.

This just happened: merging a CLI change (#419) created `v0.1.41`, and the cleanup step logged **`Deleting old release: faction-data`**. `deploy.yml` downloads faction zips + `manifest.json` from the `faction-data` release on every deploy — so the **next deploy would have shipped the live site with no factions at all**. It also broke the Faction Models manifest regeneration (which reads that release).

## Fix

Exclude the four infrastructure release tags (`latest`, `faction-data`, `faction-models`, `pa-base-data`) from the cleanup, so only versioned `vX.Y.Z` CLI releases are ever pruned. (`faction-data` itself has since been recreated by re-running the Faction Data workflow.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKbnTD3a4ozzimdY6i8UjJ