### PR TITLE
fix(3d): render texture-less unit models instead of erroring

### DIFF
--- a/web/src/components/UnitModelViewer.tsx
+++ b/web/src/components/UnitModelViewer.tsx
@@ -271,12 +271,28 @@ export function UnitModelViewer({
           )
         })
 
+      // A 1×1 fallback texture for units that ship geometry but no textures
+      // (many Exiles/Bugs units): a neutral grey diffuse reads as bare metal,
+      // and an all-zero mask means no team-colour regions and no emissive. The
+      // shader is unchanged — it just samples a solid colour.
+      const solidTexture = (r: number, g: number, b: number): THREE.Texture => {
+        const tex = new THREE.DataTexture(
+          new Uint8Array([r, g, b, 255]),
+          1,
+          1,
+          THREE.RGBAFormat
+        )
+        tex.colorSpace = THREE.NoColorSpace
+        tex.needsUpdate = true
+        return tex
+      }
+
       let diffuse: THREE.Texture
       let mask: THREE.Texture
       try {
         ;[diffuse, mask] = await Promise.all([
-          loadTexture(model.diffuseUrl),
-          loadTexture(model.maskUrl),
+          model.diffuseUrl ? loadTexture(model.diffuseUrl) : Promise.resolve(solidTexture(170, 170, 170)),
+          model.maskUrl ? loadTexture(model.maskUrl) : Promise.resolve(solidTexture(0, 0, 0)),
         ])
       } catch (err) {
         if (!cancelled) {

--- a/web/src/services/__tests__/modelLoader.test.ts
+++ b/web/src/services/__tests__/modelLoader.test.ts
@@ -32,13 +32,17 @@ configure({ useWebWorkers: false })
 
 const SAMPLE_INDEX: ModelsIndex = {
   generated: '2026-07-11T00:00:00Z',
-  unitCount: 1,
+  unitCount: 2,
   units: {
     radar: {
       glb: 'models/radar.glb',
       diffuse: 'textures/radar_diffuse.png',
       mask: 'textures/radar_mask.png',
       material: 'textures/radar_material.png',
+    },
+    // A texture-less unit (geometry only) — many Exiles/Bugs units are like this.
+    beacon: {
+      glb: 'models/beacon.glb',
     },
   },
 }
@@ -51,6 +55,7 @@ async function buildBundleBlob(): Promise<Blob> {
   await zw.add('textures/radar_diffuse.png', new Uint8ArrayReader(new Uint8Array([5, 6])))
   await zw.add('textures/radar_mask.png', new Uint8ArrayReader(new Uint8Array([7, 8])))
   await zw.add('textures/radar_material.png', new Uint8ArrayReader(new Uint8Array([9, 10])))
+  await zw.add('models/beacon.glb', new Uint8ArrayReader(new Uint8Array([11, 12, 13])))
   return zw.close()
 }
 
@@ -112,6 +117,19 @@ describe('modelLoader — development mode', () => {
 
     const model = await loadUnitModel('MLA', 'does_not_exist')
     expect(model).toBeNull()
+  })
+
+  it('loads a texture-less unit with only a glb URL (no diffuse/mask/material)', async () => {
+    global.fetch = vi.fn(async () =>
+      new Response(JSON.stringify(SAMPLE_INDEX), { status: 200 })
+    ) as unknown as typeof fetch
+
+    const model = await loadUnitModel('MLA', 'beacon')
+    expect(model).not.toBeNull()
+    expect(model!.glbUrl).toBe('/faction-models/MLA/models/beacon.glb')
+    expect(model!.diffuseUrl).toBeUndefined()
+    expect(model!.maskUrl).toBeUndefined()
+    expect(model!.materialUrl).toBeUndefined()
   })
 })
 
@@ -269,5 +287,20 @@ describe('modelLoader — production mode', () => {
 
     const model = await loadUnitModel('MLA', 'ghost', '1.0.0')
     expect(model).toBeNull()
+  })
+
+  it('loads a texture-less unit without requesting undefined bundle entries', async () => {
+    mockGetVersion.mockResolvedValue(modelsEntry())
+    mockRangeFetch()
+
+    // Regression: a unit with only a glb (no diffuse/mask/material) must not
+    // throw "Entry not found in bundle: undefined" — it renders geometry-only.
+    const model = await loadUnitModel('MLA', 'beacon', '1.0.0')
+    expect(model).not.toBeNull()
+    expect(model!.glbUrl).toMatch(/^blob:/)
+    expect(model!.diffuseUrl).toBeUndefined()
+    expect(model!.maskUrl).toBeUndefined()
+    expect(model!.materialUrl).toBeUndefined()
+    model!.release()
   })
 })

--- a/web/src/services/modelLoader.ts
+++ b/web/src/services/modelLoader.ts
@@ -62,11 +62,15 @@ export interface ModelsIndex {
   units: Record<string, ModelEntry>
 }
 
-/** A loaded unit model, as URLs ready to hand to three.js loaders. */
+/** A loaded unit model, as URLs ready to hand to three.js loaders.
+ *
+ * `diffuseUrl`/`maskUrl` are optional: some units (many Exiles/Bugs units) have
+ * geometry but no textures in the bundle, so the viewer falls back to a plain
+ * material for those. */
 export interface LoadedUnitModel {
   glbUrl: string
-  diffuseUrl: string
-  maskUrl: string
+  diffuseUrl?: string
+  maskUrl?: string
   materialUrl?: string
   /**
    * Release any object URLs created for this model. No-op in dev (plain file
@@ -110,8 +114,9 @@ interface ModelCacheDB extends DBSchema {
       // across environments, and Blobs are rebuilt in-context on read so they
       // are always valid for URL.createObjectURL.
       glb: ArrayBuffer
-      diffuse: ArrayBuffer
-      mask: ArrayBuffer
+      // Optional: some units have geometry but no textures in the bundle.
+      diffuse?: ArrayBuffer
+      mask?: ArrayBuffer
       material?: ArrayBuffer
     }
   }
@@ -403,8 +408,8 @@ export async function loadUnitModel(
     const base = `${MODELS_BASE_PATH}/${factionId}`
     return {
       glbUrl: `${base}/${entry.glb}`,
-      diffuseUrl: `${base}/${entry.diffuse}`,
-      maskUrl: `${base}/${entry.mask}`,
+      diffuseUrl: entry.diffuse ? `${base}/${entry.diffuse}` : undefined,
+      maskUrl: entry.mask ? `${base}/${entry.mask}` : undefined,
       materialUrl: entry.material ? `${base}/${entry.material}` : undefined,
       release: () => {},
     }
@@ -435,14 +440,20 @@ export async function loadUnitModel(
   const cachedUnit = await db.get('units', unitKey)
   if (cachedUnit && cachedUnit.timestamp === manifestEntry.timestamp) {
     glb = bytesToBlob(cachedUnit.glb, entry.glb)
-    diffuse = bytesToBlob(cachedUnit.diffuse, entry.diffuse)
-    mask = bytesToBlob(cachedUnit.mask, entry.mask)
+    diffuse =
+      cachedUnit.diffuse && entry.diffuse ? bytesToBlob(cachedUnit.diffuse, entry.diffuse) : undefined
+    mask = cachedUnit.mask && entry.mask ? bytesToBlob(cachedUnit.mask, entry.mask) : undefined
     material =
       cachedUnit.material && entry.material
         ? bytesToBlob(cachedUnit.material, entry.material)
         : undefined
   } else {
-    const names = [entry.glb, entry.diffuse, entry.mask]
+    // Only request the assets this unit actually has — diffuse/mask/material are
+    // absent for texture-less units, and asking for an undefined entry would
+    // throw "Entry not found in bundle: undefined".
+    const names = [entry.glb]
+    if (entry.diffuse) names.push(entry.diffuse)
+    if (entry.mask) names.push(entry.mask)
     if (entry.material) names.push(entry.material)
 
     const url = getSiteBaseUrl() + manifestEntry.models.downloadUrl
@@ -456,8 +467,8 @@ export async function loadUnitModel(
     }
 
     const glbBytes = getBytes(entry.glb)
-    const diffuseBytes = getBytes(entry.diffuse)
-    const maskBytes = getBytes(entry.mask)
+    const diffuseBytes = entry.diffuse ? getBytes(entry.diffuse) : undefined
+    const maskBytes = entry.mask ? getBytes(entry.mask) : undefined
     const materialBytes = entry.material ? getBytes(entry.material) : undefined
 
     await db.put('units', {
@@ -470,8 +481,8 @@ export async function loadUnitModel(
     })
 
     glb = bytesToBlob(glbBytes, entry.glb)
-    diffuse = bytesToBlob(diffuseBytes, entry.diffuse)
-    mask = bytesToBlob(maskBytes, entry.mask)
+    diffuse = diffuseBytes && entry.diffuse ? bytesToBlob(diffuseBytes, entry.diffuse) : undefined
+    mask = maskBytes && entry.mask ? bytesToBlob(maskBytes, entry.mask) : undefined
     material = materialBytes && entry.material ? bytesToBlob(materialBytes, entry.material) : undefined
   }
 
@@ -484,8 +495,8 @@ export async function loadUnitModel(
 
   return {
     glbUrl: makeUrl(glb),
-    diffuseUrl: makeUrl(diffuse),
-    maskUrl: makeUrl(mask),
+    diffuseUrl: diffuse ? makeUrl(diffuse) : undefined,
+    maskUrl: mask ? makeUrl(mask) : undefined,
     materialUrl: material ? makeUrl(material) : undefined,
     release: () => {
       for (const url of urls) URL.revokeObjectURL(url)

--- a/web/src/services/modelLoader.ts
+++ b/web/src/services/modelLoader.ts
@@ -47,11 +47,12 @@ import {
 // the loader run under jsdom in tests.
 configure({ useWebWorkers: false })
 
-/** One unit's model asset paths, relative to the bundle root. */
+/** One unit's model asset paths, relative to the bundle root. Only `glb` is
+ * guaranteed — texture-less units (many Exiles/Bugs units) omit the textures. */
 export interface ModelEntry {
   glb: string
-  diffuse: string
-  mask: string
+  diffuse?: string
+  mask?: string
   material?: string
 }
 


### PR DESCRIPTION
## Problem

Reported: https://pa-pedia.com/faction/exiles/unit/can (Cub) fails to load its 3D model — the viewer shows a red **"Entry not found in bundle: undefined"**.

Root cause: some units ship **geometry but no textures** — their `models.json` entry is just `{ "glb": "..." }`. `loadUnitModel` built its extract list as `[glb, diffuse, mask]` unconditionally, so an absent `diffuse`/`mask` asked the zip reader for an `undefined` entry and threw. The viewer's shader also hard-required both textures.

This isn't rare: **Exiles 90/108, Bugs 20/126, Legion 2/117** units are texture-less (MLA/Second-Wave 0). All of them hit this error.

## Fix

- **modelLoader**: `diffuse`/`mask`/`material` are now optional throughout (type, IndexedDB schema, dev + prod load paths). Only the assets a unit actually has are requested/cached; `diffuseUrl`/`maskUrl` are `undefined` when absent.
- **UnitModelViewer**: falls back to a 1x1 solid texture when one is missing — neutral grey diffuse (bare metal) + all-zero mask (no team-colour regions, no emissive) — so geometry renders cleanly through the unchanged shader.

## Verification

- Texture-less unit now renders as clean grey geometry (was a red error); textured units unchanged. Verified both in the dev viewer.
- Added dev + prod regression tests for the texture-less path (`modelLoader.test.ts`, now 12 passing). `tsc` + `eslint` clean.

## Follow-up (not this PR)

Exiles being 90/108 texture-less suggests its textures mostly aren't being extracted — likely a texture-name mismatch in the CLI staging for that mod. Worth a separate investigation so those units render textured rather than grey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKbnTD3a4ozzimdY6i8UjJ