### PR TITLE
fix(3d): hide build-platform and collision meshes in model viewer

### DIFF
--- a/web/src/components/UnitModelViewer.tsx
+++ b/web/src/components/UnitModelViewer.tsx
@@ -16,6 +16,7 @@ import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js'
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
 import type { TeamColors } from '@/types/faction'
 import { loadUnitModel, type LoadedUnitModel } from '@/services/modelLoader'
+import { isAuxiliaryMeshName } from '@/utils/auxiliaryMesh'
 
 interface UnitModelViewerProps {
   factionId: string
@@ -347,18 +348,35 @@ export function UnitModelViewer({
       if (cancelled) return
 
       const obj = gltf.scene
+      // Auxiliary meshes (build/nav platform `*_nav`, collision hull `*_col`)
+      // ship inside the model but aren't part of the unit's appearance — left in,
+      // factories render a stray "extra box". Collect them during the traverse
+      // and remove them afterwards (mutating the graph mid-traverse is unsafe).
+      const auxiliary: THREE.Mesh[] = []
       obj.traverse((n) => {
         const mesh = n as THREE.Mesh
-        if (mesh.isMesh) {
-          if (mesh.geometry) disposables.push(mesh.geometry)
-          // Dispose the MeshStandardMaterial(s) GLTFLoader auto-created before
-          // swapping in our shared team-colour material, so they don't leak.
-          const original = mesh.material
-          if (Array.isArray(original)) original.forEach((m) => m?.dispose?.())
-          else original?.dispose?.()
-          mesh.material = material
+        if (!mesh.isMesh) return
+        if (isAuxiliaryMeshName(mesh.name)) {
+          auxiliary.push(mesh)
+          return
         }
+        if (mesh.geometry) disposables.push(mesh.geometry)
+        // Dispose the MeshStandardMaterial(s) GLTFLoader auto-created before
+        // swapping in our shared team-colour material, so they don't leak.
+        const original = mesh.material
+        if (Array.isArray(original)) original.forEach((m) => m?.dispose?.())
+        else original?.dispose?.()
+        mesh.material = material
       })
+      // Drop the auxiliary meshes from the scene graph so they neither render nor
+      // skew the framing bounding box below, disposing their GPU resources.
+      for (const mesh of auxiliary) {
+        mesh.geometry?.dispose?.()
+        const mat = mesh.material
+        if (Array.isArray(mat)) mat.forEach((m) => m?.dispose?.())
+        else mat?.dispose?.()
+        mesh.removeFromParent()
+      }
 
       // Frame the model.
       const box = new THREE.Box3().setFromObject(obj)

--- a/web/src/utils/__tests__/auxiliaryMesh.test.ts
+++ b/web/src/utils/__tests__/auxiliaryMesh.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { isAuxiliaryMeshName } from '../auxiliaryMesh'
+
+describe('isAuxiliaryMeshName', () => {
+  it('flags the build/nav platform mesh (the factory "extra box")', () => {
+    expect(isAuxiliaryMeshName('air_factory_nav')).toBe(true)
+    expect(isAuxiliaryMeshName('vehicle_factory_nav')).toBe(true)
+    expect(isAuxiliaryMeshName('bot_factory_nav')).toBe(true)
+  })
+
+  it('flags the collision-hull mesh', () => {
+    expect(isAuxiliaryMeshName('bot_factory_col')).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    expect(isAuxiliaryMeshName('AIR_FACTORY_NAV')).toBe(true)
+    expect(isAuxiliaryMeshName('Bot_Factory_Col')).toBe(true)
+  })
+
+  it('keeps the real geometry mesh', () => {
+    expect(isAuxiliaryMeshName('air_factory_mesh')).toBe(false)
+    expect(isAuxiliaryMeshName('radar_mesh')).toBe(false)
+    expect(isAuxiliaryMeshName('assault_bot_mesh')).toBe(false)
+  })
+
+  it('keeps Blender-split geometry parts and detail meshes', () => {
+    // Real geometry that merely *contains* mesh/highlight tokens, or is a
+    // numbered duplicate — only a trailing _nav/_col segment is auxiliary.
+    expect(isAuxiliaryMeshName('sea_mine_mesh.001')).toBe(false)
+    expect(isAuxiliaryMeshName('tank_hover_mesh001')).toBe(false)
+    expect(isAuxiliaryMeshName('bot_aa_mesh.008_edge_highlight')).toBe(false)
+  })
+
+  it('only matches a trailing _nav/_col segment, not substrings', () => {
+    expect(isAuxiliaryMeshName('navmesh')).toBe(false)
+    expect(isAuxiliaryMeshName('some_navy')).toBe(false)
+    expect(isAuxiliaryMeshName('color_mesh')).toBe(false)
+  })
+
+  it('handles empty / missing names', () => {
+    expect(isAuxiliaryMeshName('')).toBe(false)
+    expect(isAuxiliaryMeshName(undefined)).toBe(false)
+    expect(isAuxiliaryMeshName(null)).toBe(false)
+  })
+})

--- a/web/src/utils/auxiliaryMesh.ts
+++ b/web/src/utils/auxiliaryMesh.ts
@@ -1,0 +1,19 @@
+/**
+ * PA unit models bundle auxiliary meshes alongside the visible geometry:
+ *   - `*_nav` — the build/nav platform units are placed on top of while being
+ *     constructed (a second object that isn't part of the unit's appearance).
+ *   - `*_col` — the collision hull, invisible in-game.
+ *
+ * Neither belongs in the 3D showcase viewer — left in, factories render a stray
+ * "extra box" next to the actual model. This predicate flags those meshes so the
+ * viewer can drop them.
+ *
+ * The match is on a trailing `_nav`/`_col` segment of the mesh/node name only.
+ * Real geometry that merely *contains* those tokens — Blender-split duplicates
+ * (`..._mesh.001`), detail meshes (`..._edge_highlight`), or names like
+ * `navmesh` — is kept.
+ */
+export function isAuxiliaryMeshName(name: string | undefined | null): boolean {
+  if (!name) return false
+  return /_(?:nav|col)$/i.test(name)
+}


### PR DESCRIPTION
## What

Filters out **auxiliary meshes** from the 3D unit model viewer so factories no longer render a stray "extra box" next to the actual model.

## Why

Reported by Nik for the MLA air factory (and affecting all factory-type units): PA unit models bundle a second object alongside the visible geometry —
- `*_nav` — the **build/nav platform** units are placed on top of *while being constructed* (Nik: "a second object … used to place units on top of it while they are being constructed")
- `*_col` — the **collision hull**, invisible in-game

Neither is part of the unit's appearance, so the showcase viewer shouldn't draw them.

## How

- New pure predicate `isAuxiliaryMeshName` matches **only a trailing `_nav`/`_col` segment**. Real geometry that merely contains those tokens — Blender-split duplicates (`..._mesh.001`), detail meshes (`..._edge_highlight`), names like `navmesh` — is kept.
- The viewer collects matching meshes during its scene traverse and removes them afterwards (mutating the graph mid-traverse is unsafe), disposing their GPU resources so nothing leaks and the framing bounding box isn't skewed.

## Verification

- Scanned **all 192 MLA unit models**: exactly 9 auxiliary meshes (`_nav`×8, `_col`×1), all on factory-type units — everything else is `_mesh`.
- Unit tests for the predicate (7 cases, incl. the keep-these edge cases).
- Full web suite green (877 tests).
- Browser-verified in a local prod preview: MLA air factory renders **without** the extra box, factory geometry intact; a normal single-mesh unit (Dox) unaffected.

## Follow-up (not here)

Optionally strip `_nav`/`_col` at model **extraction** time too (smaller bundles), but that needs regenerating all model bundles — noted for #408. This render-time filter fixes every existing bundle immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)