### PR TITLE
fix(profiles): add Exiles client mod so unit textures resolve

### DIFF
--- a/cli/profiles/embedded/exiles.json
+++ b/cli/profiles/embedded/exiles.json
@@ -1,7 +1,10 @@
 {
   "displayName": "Exiles",
   "factionUnitType": "Custom6",
-  "mods": ["github.com/NikolaMX/Exiles-Faction"],
+  "mods": [
+    "github.com/NikolaMX/Exiles-Faction",
+    "github.com/NikolaMX/exiles_faction_client"
+  ],
   "backgroundImage": "/ui/mods/com.pa.nik.exiles/img/background.png",
   "teamColors": {
     "primary": "#7c3aed",


### PR DESCRIPTION
## What

Adds the Exiles **client mod** (`github.com/NikolaMX/exiles_faction_client`) as a second source in the Exiles profile, so unit textures resolve during model extraction.

## Why

PA keeps unit textures in the **client** mod. The Exiles profile listed only the server mod (`Exiles-Faction`), which ships models but no textures — so **90 of 108 Exiles units extracted texture-less** (only the 18 reusing base-game assets had textures).

Every other modded faction already lists its client mod and is ~fully textured:

| Faction | Textured | Client mod listed? |
|---|---|---|
| Legion | 115/117 (98%) | ✅ |
| Second-Wave | 44/44 (100%) | ✅ |
| Bugs | 106/126 (84%) | ✅ |
| **Exiles (before)** | **18/108 (17%)** | ❌ |

The model extractor resolves textures as `<model>_diffuse.papa` siblings across the mod overlay (`cli/pkg/models3d/pipeline.go`, `texturePapaPaths`), silently skipping when absent. The client repo contains **98 `_diffuse`/`_mask`/`_material.papa` sets** — verified e.g. `pa/units/land/can/can_diffuse.papa` — matching exactly what the extractor looks for.

Ordering is server-first, client-second (first-wins), matching the Legion/Bugs profiles.

## ⚠️ Requires a regen to take effect

This profile change does nothing on its own. To realise the textures:
1. **Re-run Exiles faction-data extraction** — confirms the added client source doesn't perturb unit data (first-wins keeps the server JSON; expected no-op for `units.json`).
2. **Run the `faction-models` Blender workflow for Exiles** — this actually produces the texture PNGs and regenerates the model bundle. Heavy, manual-dispatch.

Expected result: Exiles ~17% → near-complete textures (~90 more units).

## Verification done here
- JSON valid; `go test ./pkg/profiles/...` passes; `go build ./...` clean.
- Grounded against the live repos: server repo has 0 texture `.papa`; client repo has 98 `_diffuse`/`_mask`/`_material.papa` sets incl. `can`'s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)