### PR TITLE
fix(3d): key model cache on bundle stamp + keep old model bundles

### DIFF
--- a/scripts/upload-model-bundles.ts
+++ b/scripts/upload-model-bundles.ts
@@ -4,8 +4,11 @@
  * Mirrors upload-to-releases.ts but targets a SEPARATE release tag so the heavy
  * model bundles never interfere with the fast `faction-data` (spec zip) release.
  * Reads models/dist/model-build-summary.json (written by build-model-bundles.ts)
- * and uploads each `{id}-{version}-pedia{ts}-models.zip`, deleting older
- * timestamps of the same faction+version (different versions are preserved).
+ * and uploads each `{id}-{version}-pedia{ts}-models.zip`. All prior bundles are
+ * preserved (both older versions AND older rebuilds of the same version): the
+ * manifest generator always selects the newest stamp per faction+version, and
+ * keeping the previous bundle avoids 404-ing the baked prod manifest until the
+ * next deploy.
  *
  * Prerequisites: GitHub CLI (gh) authenticated (GITHUB_TOKEN in CI).
  */
@@ -64,27 +67,6 @@ function ensureReleaseExists(): void {
   )
 }
 
-function escapeRegex(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-}
-
-/** Delete older timestamps of the same faction+version (preserve other versions). */
-function deleteSameVersionDuplicates(factionId: string, version: string, newFilename: string): void {
-  const output = execSync(`gh release view ${RELEASE_TAG} --json assets -q ".assets[].name"`, {
-    encoding: 'utf-8',
-  })
-  const assets = output.trim().split('\n').filter(Boolean)
-  const sameVersionPattern = new RegExp(
-    `^${escapeRegex(factionId)}-${escapeRegex(version)}-pedia\\d{14}-models\\.zip$`,
-    'i'
-  )
-  const duplicates = assets.filter((name) => sameVersionPattern.test(name) && name !== newFilename)
-  for (const asset of duplicates) {
-    console.log(`  Deleting older timestamp: ${asset}`)
-    exec(`gh release delete-asset ${RELEASE_TAG} "${asset}" --yes`, { silent: true })
-  }
-}
-
 function uploadZip(filename: string): void {
   const zipPath = path.join(OUTPUT_DIR, filename)
   if (!fs.existsSync(zipPath)) {
@@ -120,7 +102,12 @@ async function main() {
 
   for (const bundle of summary.bundles) {
     console.log(`Processing ${bundle.factionId} v${bundle.version} (${bundle.unitCount} units)...`)
-    deleteSameVersionDuplicates(bundle.factionId, bundle.version, bundle.filename)
+    // Old timestamps of the same faction+version are intentionally KEPT. The
+    // baked prod manifest (deployed from the previous run) still points at the
+    // previous bundle until the next deploy; deleting it here would 404 the 3D
+    // viewer in that window. `buildModelBundleMap` (generate-manifest) always
+    // picks the newest stamp per faction+version, so keeping older rebuilds is
+    // harmless — and preserves model history alongside the spec-zip history.
     uploadZip(bundle.filename)
     console.log()
   }

--- a/web/src/services/__tests__/modelLoader.test.ts
+++ b/web/src/services/__tests__/modelLoader.test.ts
@@ -242,6 +242,52 @@ describe('modelLoader — production mode', () => {
     expect(wholeBundleDownloads).toBe(0)
   })
 
+  it('invalidates the cache when a model-only regen produces a new bundle (same faction-data timestamp)', async () => {
+    // A model regen keeps the faction-data `timestamp` unchanged but ships a new
+    // bundle filename with a new build stamp. The cache must key on the bundle
+    // stamp, not the faction-data timestamp — otherwise stale (e.g. texture-less)
+    // models keep being served after a regen.
+    const oldEntry = {
+      ...modelsEntry(),
+      // faction-data timestamp stays constant across the regen
+      timestamp: 100,
+      models: {
+        filename: 'mla-1.0.0-pedia20260101000000-models.zip',
+        downloadUrl: '/faction-models/mla-1.0.0-pedia20260101000000-models.zip',
+        size: bundleBytes.byteLength,
+        unitCount: 1,
+      },
+    }
+    mockGetEntry.mockResolvedValue(oldEntry)
+    mockRangeFetch()
+
+    const first = await getFactionModelsIndex('MLA')
+    expect(first).not.toBeNull()
+    const callsAfterFirst = vi.mocked(global.fetch).mock.calls.length
+
+    // Same bundle again → cache hit, no new network.
+    await getFactionModelsIndex('MLA')
+    expect(vi.mocked(global.fetch).mock.calls.length).toBe(callsAfterFirst)
+
+    // Model-only regen: NEW bundle filename/stamp, SAME faction-data timestamp.
+    const newEntry = {
+      ...oldEntry,
+      timestamp: 100,
+      models: {
+        filename: 'mla-1.0.0-pedia20260202000000-models.zip',
+        downloadUrl: '/faction-models/mla-1.0.0-pedia20260202000000-models.zip',
+        size: bundleBytes.byteLength,
+        unitCount: 1,
+      },
+    }
+    mockGetEntry.mockResolvedValue(newEntry)
+
+    const refreshed = await getFactionModelsIndex('MLA')
+    expect(refreshed).not.toBeNull()
+    // Cache MUST have been invalidated → a fresh range read happened.
+    expect(vi.mocked(global.fetch).mock.calls.length).toBeGreaterThan(callsAfterFirst)
+  })
+
   it('getFactionModelsIndex never whole-bundle-downloads on page load when Range is unsupported', async () => {
     // A CDN that ignores Range (200, no accept-ranges). The precheck must degrade
     // to "no models" rather than downloading the entire bundle just to check.

--- a/web/src/services/modelLoader.ts
+++ b/web/src/services/modelLoader.ts
@@ -340,11 +340,13 @@ export async function getFactionModelsIndex(
 
   const resolvedVersion = version ?? manifestEntry.version
   const cacheKey = `${factionId.toLowerCase()}@${resolvedVersion}`
+  const bundleStamp = modelBundleStamp(manifestEntry)
 
-  // Version-aware cache check.
+  // Cache freshness keys on the MODEL bundle stamp (not the faction-data
+  // timestamp) so a model-only regen invalidates stale entries.
   const db = await getDB()
   const cached = await db.get('indexes', cacheKey)
-  if (cached && cached.timestamp === manifestEntry.timestamp) {
+  if (cached && cached.timestamp === bundleStamp) {
     return cached.index
   }
 
@@ -361,7 +363,7 @@ export async function getFactionModelsIndex(
     const extracted = await extractEntries(
       url,
       cacheKey,
-      manifestEntry.timestamp,
+      bundleStamp,
       ['models.json'],
       false // no whole-bundle fallback on page load
     )
@@ -375,11 +377,29 @@ export async function getFactionModelsIndex(
   const index = JSON.parse(new TextDecoder().decode(bytes)) as ModelsIndex
   await db.put('indexes', {
     key: cacheKey,
-    timestamp: manifestEntry.timestamp,
+    timestamp: bundleStamp,
     index,
     cachedAt: new Date().toISOString(),
   })
   return index
+}
+
+/**
+ * Freshness token for a faction's model bundle.
+ *
+ * A model-only regen (the `faction-models` workflow) keeps the faction-data
+ * `timestamp` unchanged but ships a NEW bundle filename carrying a new build
+ * stamp. So the model cache must key on the bundle's own stamp — the 14-digit
+ * `pedia<YYYYMMDDHHmmss>` in `{id}-{version}-pedia{stamp}-models.zip` — NOT
+ * `manifestEntry.timestamp` (the spec-zip timestamp), which would leave stale
+ * (e.g. texture-less) models cached indefinitely after a regen.
+ *
+ * Falls back to the faction-data timestamp only if the filename is unparseable,
+ * which should not happen for a real bundle.
+ */
+function modelBundleStamp(entry: { timestamp: number; models?: { filename: string } }): number {
+  const match = entry.models?.filename.match(/pedia(\d{14})-models\.zip$/i)
+  return match ? Number(match[1]) : entry.timestamp
 }
 
 function mimeForPath(path: string): string {
@@ -425,6 +445,7 @@ export async function loadUnitModel(
   const resolvedVersion = version ?? manifestEntry.version
   const bundleKey = `${factionId.toLowerCase()}@${resolvedVersion}`
   const unitKey = `${bundleKey}/${unitId}`
+  const bundleStamp = modelBundleStamp(manifestEntry)
   const db = await getDB()
 
   // Rebuild a Blob from stored bytes in the current context so it is always a
@@ -439,7 +460,7 @@ export async function loadUnitModel(
   let material: Blob | undefined
 
   const cachedUnit = await db.get('units', unitKey)
-  if (cachedUnit && cachedUnit.timestamp === manifestEntry.timestamp) {
+  if (cachedUnit && cachedUnit.timestamp === bundleStamp) {
     glb = bytesToBlob(cachedUnit.glb, entry.glb)
     diffuse =
       cachedUnit.diffuse && entry.diffuse ? bytesToBlob(cachedUnit.diffuse, entry.diffuse) : undefined
@@ -458,7 +479,7 @@ export async function loadUnitModel(
     if (entry.material) names.push(entry.material)
 
     const url = getSiteBaseUrl() + manifestEntry.models.downloadUrl
-    const extracted = await extractEntries(url, bundleKey, manifestEntry.timestamp, names)
+    const extracted = await extractEntries(url, bundleKey, bundleStamp, names)
 
     // Copy each entry into a fresh ArrayBuffer that owns exactly its bytes.
     const getBytes = (name: string): ArrayBuffer => {
@@ -474,7 +495,7 @@ export async function loadUnitModel(
 
     await db.put('units', {
       key: unitKey,
-      timestamp: manifestEntry.timestamp,
+      timestamp: bundleStamp,
       glb: glbBytes,
       diffuse: diffuseBytes,
       mask: maskBytes,


### PR DESCRIPTION
## Problem

Two coupled issues surfaced while shipping the Exiles client-mod texture fix (#424):

1. **Stale models served after a model-only regen.** `modelLoader` keyed its IndexedDB cache freshness on `manifestEntry.timestamp` — the **faction-data** (spec-zip) timestamp. The `faction-models` regen produces a new textured bundle but does **not** change the spec-zip timestamp, so previously-cached (texture-less) models were treated as fresh and kept being served. Anyone who had viewed Exiles models before the fix (likely including me) would never see the new textures until their `pa-pedia-model-cache` DB cleared.

2. **Transient broken 3D between regen and deploy.** `upload-model-bundles` deleted the previous same-version bundle on upload. But prod serves the **baked** manifest from the last deploy, which still references that now-deleted bundle → the viewer 404s until the next deploy.

## Fix

- **Cache freshness now keys on the model bundle's own build stamp** — the 14-digit `pedia<YYYYMMDDHHmmss>` embedded in `models.filename`, which changes on every regen. Works against the **currently-deployed** manifest with no manifest regen needed; existing stale entries invalidate naturally on the stamp mismatch. New regression test asserts a new bundle stamp invalidates the cache even when the faction-data timestamp is unchanged.
- **Stop deleting older same-version model bundles.** `generate-manifest`'s `buildModelBundleMap` already selects the newest stamp per faction+version, so keeping older rebuilds is harmless — and it means the previous baked manifest keeps working until a deploy refreshes it. Also preserves model history alongside the spec-zip version history.

## Testing

- `just web-test-run` — 871 pass (incl. new invalidation test)
- `just web-lint` — clean
- `scripts` `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)