### PR TITLE
fix(compare): stack breadcrumb selectors when comparison columns get narrow

### DIFF
--- a/web/src/components/BreadcrumbNav.tsx
+++ b/web/src/components/BreadcrumbNav.tsx
@@ -238,9 +238,11 @@ export function BreadcrumbNav({ factionId, unitId, version = null, onUnitChange,
   )
 
   return (
-    <nav aria-label="Unit navigation" className="w-full sm:w-auto">
-      <div className="flex flex-col sm:flex-row sm:inline-flex items-stretch sm:items-center gap-2 p-2 bg-gray-100 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700">
-        <div className="w-full sm:w-auto sm:min-w-[140px]">
+    <nav aria-label="Unit navigation" className="@container w-full">
+      {/* Layout responds to the nav's own width (container query), not the viewport,
+          so comparison columns stack their selectors once they get narrow (3+ units). */}
+      <div className="flex flex-col @lg:flex-row @lg:inline-flex items-stretch @lg:items-center gap-2 p-2 bg-gray-100 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700">
+        <div className="w-full @lg:w-auto @lg:min-w-[140px]">
           <Select<FactionOption>
             options={factionOptions}
             value={selectedFaction}
@@ -257,16 +259,18 @@ export function BreadcrumbNav({ factionId, unitId, version = null, onUnitChange,
 
         {/* Version selector - between faction and unit selectors */}
         {showVersionSelector && (
-          <VersionSelector
-            factionId={factionId}
-            currentVersion={version}
-            onVersionChange={handleVersionChange}
-          />
+          <div className="w-full @lg:w-auto">
+            <VersionSelector
+              factionId={factionId}
+              currentVersion={version}
+              onVersionChange={handleVersionChange}
+            />
+          </div>
         )}
 
-        <span className="text-gray-400 dark:text-gray-500 text-lg hidden sm:inline self-center">&rarr;</span>
+        <span className="text-gray-400 dark:text-gray-500 text-lg hidden @lg:inline self-center">&rarr;</span>
 
-        <div className={`w-full sm:w-auto ${isAllFactionsSelected ? 'sm:min-w-[280px]' : 'sm:min-w-[200px]'}`}>
+        <div className={`w-full @lg:w-auto ${isAllFactionsSelected ? '@lg:min-w-[280px]' : '@lg:min-w-[200px]'}`}>
           <Select<UnitOptionWithFaction>
             options={unitOptions}
             value={selectedUnit}

--- a/web/src/pages/UnitDetail.tsx
+++ b/web/src/pages/UnitDetail.tsx
@@ -1394,7 +1394,9 @@ export function UnitDetail() {
           <>
             {/* Non-comparison mode - navigation with Compare button */}
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
-              <BreadcrumbNav factionId={factionId || ''} unitId={unitId} version={version} />
+              <div className="w-full min-w-0 sm:flex-1">
+                <BreadcrumbNav factionId={factionId || ''} unitId={unitId} version={version} />
+              </div>
               <button
                 onClick={() => {
                   // Start comparison mode with one empty slot for selection


### PR DESCRIPTION
## Problem

When comparing **3+ units**, each comparison column drops to ~33% width. The `BreadcrumbNav`'s faction / version / unit selectors are laid out **side-by-side based on the viewport**, so once the column is narrow they overflow into the neighbouring column and appear squished/overlapping.

![before](reported screenshot: three selector bars overlapping)

## Fix

Drive `BreadcrumbNav`'s layout by **its own available width** using a Tailwind v4 container query (`@container` + `@lg:`) instead of the viewport:

- **Below 512px** (narrow comparison column): selectors stack vertically — faction/version on top, unit below, each full-width, `→` arrow hidden. This is the "break to a second row within the same container" behaviour.
- **At/above 512px** (1–2 units, or wide screens): stays inline exactly as before.

Because it keys off real column width, it flips at the 3-unit point automatically and also does the right thing on smaller screens and for the wider "All factions" unit picker.

The standalone single-unit page wraps the nav in `sm:flex-1 min-w-0` so it still reports full page width and renders inline beside the Compare button — no visual change there.

## Files

- `web/src/components/BreadcrumbNav.tsx` — `@container` + `@lg:` layout; version selector wrapped for full-width stacking.
- `web/src/pages/UnitDetail.tsx` — standalone nav wrapper so it keeps full width.

## Verification

Manually verified in-browser (`just dev` and `just dev-live`):

- **2 units** → inline with `→` (unchanged)
- **3 units** → selectors stack cleanly, no overlap
- **standalone unit page** → inline, no regression
- **live mode** (version selector present) → version dropdown stacks as its own full-width row

`BreadcrumbNav` tests 13/13 pass; `tsc --noEmit` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)