### PR TITLE
fix(3d): fetch model bundles same-origin so dev-live can load them

### DIFF
--- a/web/src/services/modelLoader.ts
+++ b/web/src/services/modelLoader.ts
@@ -38,7 +38,7 @@ import {
   getManifestEntry,
   getManifestVersion,
   isDevelopmentMode,
-  getSiteBaseUrl,
+  type ModelBundleInfo,
 } from './manifestLoader'
 
 // Run zip decompression inline (no web workers). Bundle entries are already
@@ -81,6 +81,24 @@ export interface LoadedUnitModel {
 }
 
 const MODELS_BASE_PATH = `${import.meta.env.BASE_URL}faction-models`
+
+/**
+ * URL of a faction's model bundle zip.
+ *
+ * Deliberately RELATIVE, unlike faction data (which dev-live fetches straight
+ * from the production origin via `getSiteBaseUrl`). We read these bundles with
+ * Range requests to pull one unit out of a large zip, and `Range` is not a
+ * CORS-safelisted header — so fetching cross-origin makes the browser preflight,
+ * and the /faction-models Pages Function answers only GET/HEAD with no CORS
+ * headers (it is same-origin in prod, so it never needs them). The preflight
+ * fails and the viewer concludes there are no models.
+ *
+ * Staying relative keeps the browser same-origin in every mode: prod hits the
+ * Pages Function directly, dev-live goes through the vite proxy (vite.config.ts).
+ */
+function modelBundleUrl(models: ModelBundleInfo): string {
+  return models.downloadUrl
+}
 
 /**
  * Dev-local mode: dev server without live production data. In this mode model
@@ -357,7 +375,7 @@ export async function getFactionModelsIndex(
   // having no viewable models this session (graceful — no button, no big fetch).
   // The actual model download (loadUnitModel) keeps the fallback, since that only
   // runs after the user clicks.
-  const url = getSiteBaseUrl() + manifestEntry.models.downloadUrl
+  const url = modelBundleUrl(manifestEntry.models)
   let bytes: Uint8Array | undefined
   try {
     const extracted = await extractEntries(
@@ -478,7 +496,7 @@ export async function loadUnitModel(
     if (entry.mask) names.push(entry.mask)
     if (entry.material) names.push(entry.material)
 
-    const url = getSiteBaseUrl() + manifestEntry.models.downloadUrl
+    const url = modelBundleUrl(manifestEntry.models)
     const extracted = await extractEntries(url, bundleKey, bundleStamp, names)
 
     // Copy each entry into a fresh ArrayBuffer that owns exactly its bytes.

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -173,6 +173,12 @@ function devContentType(ext: string): string {
   return contentTypes[ext] || 'application/octet-stream'
 }
 
+/** `just dev-live`: dev server backed by real production faction data. */
+const DEV_LIVE = process.env.VITE_USE_LIVE_DATA === 'true'
+
+/** Production origin that dev-live borrows faction + model data from. */
+const PRODUCTION_ORIGIN = 'https://pa-pedia.com'
+
 /**
  * Custom plugin to serve /faction-models from the repo-root faction-models/ dir.
  *
@@ -185,6 +191,9 @@ function devContentType(ext: string): string {
  *
  * Kept separate from /factions so the faction-data zip workflow is untouched.
  * Can be overridden via VITE_FACTION_MODELS_DIR (e.g. for E2E fixtures).
+ *
+ * Skipped in dev-live, where model bundles come from production via the proxy
+ * below rather than from local files (see DEV_LIVE).
  */
 function serveFactionModels(): Plugin {
   const modelsDir = path.resolve(__dirname, process.env.VITE_FACTION_MODELS_DIR || '../faction-models')
@@ -192,6 +201,10 @@ function serveFactionModels(): Plugin {
   return {
     name: 'serve-faction-models',
     configureServer(server) {
+      // dev-live serves these from production through the proxy; local files
+      // must not shadow it.
+      if (DEV_LIVE) return
+
       server.middlewares.use('/faction-models', (req, res, next) => {
         const reqUrl = req.url || ''
         const filePath = path.join(modelsDir, reqUrl.split('?')[0])
@@ -224,5 +237,22 @@ export default defineConfig({
       // Allow serving files from the factions folder at repo root
       allow: ['..'],
     },
+    // dev-live reads model bundles from production. Fetching them cross-origin
+    // does not work: zip.js sends a Range header to read a single unit out of
+    // the bundle, Range is not CORS-safelisted, so the browser preflights — and
+    // the Cloudflare Pages Function that serves /faction-models only answers
+    // GET/HEAD and sets no CORS headers (it is same-origin in prod, so it never
+    // needs them). The preflight fails and the 3D viewer sees "no models".
+    //
+    // Proxying here keeps the browser same-origin, exactly as in production, so
+    // no CORS is involved and production needs no dev-only concessions.
+    ...(DEV_LIVE && {
+      proxy: {
+        '/faction-models': {
+          target: PRODUCTION_ORIGIN,
+          changeOrigin: true,
+        },
+      },
+    }),
   },
 })


### PR DESCRIPTION
## Problem

`just dev-live` showed a "no 3D model" state for **every** unit, including units whose models demonstrably exist in production.

## Root cause

Model bundle URLs were built as `getSiteBaseUrl() + downloadUrl`. In dev-live that resolves to the production origin, so the browser fetched bundles **cross-origin**:

1. zip.js reads a single unit out of a large bundle using a `Range` header.
2. `Range` is not CORS-safelisted → the browser must send an `OPTIONS` preflight.
3. The `/faction-models` Pages Function answers only GET/HEAD and sets no CORS headers — it is same-origin in production, so it never needed them.
4. The preflight 405s → the fetch rejects → the index read fails → reported as "no models".

Faction data was unaffected because Cloudflare Pages auto-adds `access-control-allow-origin: *` to **static** assets (manifest, faction zips). Function responses get no such header, so model bundles were the one thing dev-live could not fetch.

## Fix

Keep the bundle URL **relative**, and proxy `/faction-models` → production from the dev server.

The browser is then same-origin in every mode, exactly as in production — no preflight, no CORS, and no dev-only concessions shipped to the Pages Function. Adding CORS to the Function was considered and rejected: production never needs it, so the only beneficiary would be `localhost`.

## Production impact

**None.** Production already resolved this path same-origin; the relative URL is what it was already effectively using (`getSiteBaseUrl()` returns `''` in prod).

## Verification

- `curl` through the proxy returns `206 Partial Content` with correct `Content-Range`.
- dev-live loads the live MLA index (**192 units**), the button enables, and a model renders — no range warnings.
- 892 unit tests, typecheck, lint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
