### PR TITLE
feat(3d): explain why the 3D model button is unavailable, and reset colours per faction

### DIFF
--- a/web/src/components/UnitModelModal.tsx
+++ b/web/src/components/UnitModelModal.tsx
@@ -75,7 +75,11 @@ export function UnitModelModal({
               </div>
             }
           >
+            {/* Keyed on faction so a faction change remounts the viewer, re-seeding
+                the colour pickers from that faction's defaults rather than keeping
+                the previous faction's picks. */}
             <UnitModelViewer
+              key={factionId}
               factionId={factionId}
               unitId={unitId}
               version={version}

--- a/web/src/components/UnitModelSection.tsx
+++ b/web/src/components/UnitModelSection.tsx
@@ -4,13 +4,21 @@
  * Graceful gatekeeper for the 3D model viewer on the Unit Detail page.
  *
  * On mount it consults the faction's model availability index (`models.json`,
- * a few KB). If the unit has a model it shows a "View 3D Model" button; if not —
- * or if the faction has no model bundle — it renders nothing, so the page works
- * with specs + icon exactly as before with no failed network request.
+ * a few KB) and always renders a button, in one of four states:
+ *
+ * - `checking` — disabled "Checking…" while the lookup is in flight
+ * - `available` — the live "View 3D Model" trigger
+ * - `none` — disabled; the unit has no model, or the faction has no bundle
+ * - `error` — disabled; the lookup FAILED, so we don't know either way
+ *
+ * Showing a disabled button rather than hiding it is deliberate: absence should
+ * be explained, not silent. `none` and `error` are kept apart just as carefully
+ * — a failed check must never claim the model doesn't exist, and the error
+ * tooltip carries no detail from the underlying failure.
  *
  * The heavy work (three.js chunk + the unit's glb/textures) is deferred until
- * the user clicks the button, which opens {@link UnitModelModal}. Nothing large
- * is downloaded on page load.
+ * the user clicks the live trigger, which opens {@link UnitModelModal}. Nothing
+ * large is downloaded on page load.
  */
 
 import { useEffect, useReducer, useState } from 'react'
@@ -27,8 +35,53 @@ interface UnitModelSectionProps {
   unitName?: string
 }
 
-type Availability = 'checking' | 'available' | 'none'
-type AvailabilityAction = { type: 'CHECK' } | { type: 'RESOLVE'; available: boolean }
+type Availability = 'checking' | 'available' | 'none' | 'error'
+type AvailabilityAction =
+  | { type: 'CHECK' }
+  | { type: 'RESOLVE'; available: boolean }
+  | { type: 'FAIL' }
+
+/**
+ * Tooltip when the unit genuinely has no model — the unit is missing from the
+ * faction's bundle, or the faction has no bundle at all. Both are permanent
+ * states for this version, so the wording is a statement of fact.
+ */
+const UNAVAILABLE_REASON = 'No 3D model is available for this unit at this version.'
+
+/**
+ * Tooltip when the availability check FAILED. Deliberately says nothing about
+ * whether a model exists (we don't know) and carries no detail from the
+ * underlying error — that stays in the console. Claiming "no model" here would
+ * assert something false about data that may well exist.
+ */
+const ERROR_REASON = "Couldn't check for a 3D model. Try reloading the page."
+
+const BUTTON_BASE =
+  'mt-4 inline-flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition-colors'
+
+/** Shared look for the two non-actionable states (checking, unavailable). */
+const INERT_BUTTON = `${BUTTON_BASE} cursor-not-allowed border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900 text-gray-400 dark:text-gray-600 opacity-60`
+
+function Spinner() {
+  return (
+    <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+        fill="none"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+      />
+    </svg>
+  )
+}
 
 // useReducer (rather than useState) so we can dispatch synchronously inside the
 // effect without tripping react-hooks/set-state-in-effect (mirrors useFaction).
@@ -38,6 +91,8 @@ function availabilityReducer(_state: Availability, action: AvailabilityAction): 
       return 'checking'
     case 'RESOLVE':
       return action.available ? 'available' : 'none'
+    case 'FAIL':
+      return 'error'
     default:
       return _state
   }
@@ -63,7 +118,10 @@ export function UnitModelSection({
         dispatch({ type: 'RESOLVE', available: !!index?.units[unitId] })
       })
       .catch(() => {
-        if (!cancelled) dispatch({ type: 'RESOLVE', available: false })
+        // The error object is intentionally not captured: modelLoader already
+        // logs the detail for developers, and nothing about it may reach the UI.
+        // A failure is NOT "no model" — see ERROR_REASON.
+        if (!cancelled) dispatch({ type: 'FAIL' })
       })
 
     return () => {
@@ -71,8 +129,35 @@ export function UnitModelSection({
     }
   }, [factionId, unitId, version])
 
-  // While checking, or when unavailable, render nothing extra.
-  if (availability !== 'available') return null
+  if (availability === 'checking') {
+    return (
+      <button type="button" data-testid="view-3d-model-checking" disabled className={INERT_BUTTON}>
+        <Spinner />
+        Checking…
+      </button>
+    )
+  }
+
+  if (availability === 'none' || availability === 'error') {
+    // aria-disabled, not the disabled attribute: a truly disabled button suppresses
+    // pointer events, so the title tooltip explaining the absence would never show.
+    // This keeps it hoverable and focusable, so the reason reaches keyboard and
+    // screen-reader users too.
+    return (
+      <button
+        type="button"
+        data-testid="view-3d-model"
+        data-state={availability}
+        aria-disabled="true"
+        title={availability === 'error' ? ERROR_REASON : UNAVAILABLE_REASON}
+        onClick={(e) => e.preventDefault()}
+        className={INERT_BUTTON}
+      >
+        <span aria-hidden="true">🧊</span>
+        View 3D Model
+      </button>
+    )
+  }
 
   return (
     <>
@@ -80,7 +165,7 @@ export function UnitModelSection({
         type="button"
         data-testid="view-3d-model"
         onClick={() => setOpen(true)}
-        className="mt-4 inline-flex items-center gap-2 rounded-lg border border-gray-300 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 px-4 py-2 text-sm font-medium text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+        className={`${BUTTON_BASE} border-gray-300 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700`}
       >
         <span aria-hidden="true">🧊</span>
         View 3D Model

--- a/web/src/components/UnitModelViewer.tsx
+++ b/web/src/components/UnitModelViewer.tsx
@@ -6,7 +6,8 @@
  * an R/G/B channel mask are tinted at runtime by a small ShaderMaterial
  * (ported from the validated spike): mask R = main region, G = highlight
  * region, B = emissive. Two colour pickers drive the tint live; the choice is
- * persisted globally in localStorage and can be reset to the faction default.
+ * persisted per faction (see {@link readTeamColorPref}) and can be reset to the
+ * faction default.
  */
 
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
@@ -16,6 +17,7 @@ import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js'
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
 import type { TeamColors } from '@/types/faction'
 import { loadUnitModel, type LoadedUnitModel } from '@/services/modelLoader'
+import { readTeamColorPref, writeTeamColorPref, clearTeamColorPref } from '@/services/teamColorPref'
 import { isAuxiliaryMeshName } from '@/utils/auxiliaryMesh'
 
 interface UnitModelViewerProps {
@@ -34,44 +36,6 @@ interface UnitModelViewerProps {
 
 /** Neutral fallback used when a faction defines no team colours. */
 const NEUTRAL_COLORS: TeamColors = { primary: '#6b7280', secondary: '#9ca3af' }
-
-/** Global localStorage key for the user's team-colour preference. */
-const COLOR_PREF_KEY = 'pa-pedia-team-colors'
-
-interface ColorPref {
-  main: string
-  highlight: string
-}
-
-function readColorPref(): ColorPref | null {
-  try {
-    const raw = localStorage.getItem(COLOR_PREF_KEY)
-    if (!raw) return null
-    const parsed = JSON.parse(raw) as Partial<ColorPref>
-    if (typeof parsed.main === 'string' && typeof parsed.highlight === 'string') {
-      return { main: parsed.main, highlight: parsed.highlight }
-    }
-  } catch {
-    // Corrupt / unavailable storage → treat as no preference.
-  }
-  return null
-}
-
-function writeColorPref(pref: ColorPref): void {
-  try {
-    localStorage.setItem(COLOR_PREF_KEY, JSON.stringify(pref))
-  } catch {
-    // Ignore storage failures (private mode / quota).
-  }
-}
-
-function clearColorPref(): void {
-  try {
-    localStorage.removeItem(COLOR_PREF_KEY)
-  } catch {
-    // Ignore.
-  }
-}
 
 // Cache the WebGL probe at module scope: it creates a canvas + GL context, and
 // creating one per viewer mount needlessly consumes scarce WebGL contexts
@@ -137,10 +101,13 @@ export function UnitModelViewer({
 
   const webglAvailable = useMemo(() => isWebGLAvailable(), [])
 
-  // Colour state: user preference (global) seeds initial values, else faction default.
-  const [main, setMain] = useState<string>(() => readColorPref()?.main ?? factionDefault.primary)
+  // Colour state: a preference picked for THIS faction seeds the pickers; anything
+  // else (no pref, or one picked on another faction) opens in faction defaults.
+  const [main, setMain] = useState<string>(
+    () => readTeamColorPref(factionId)?.main ?? factionDefault.primary
+  )
   const [highlight, setHighlight] = useState<string>(
-    () => readColorPref()?.highlight ?? factionDefault.secondary
+    () => readTeamColorPref(factionId)?.highlight ?? factionDefault.secondary
   )
 
   const [loadState, setLoadState] = useState<LoadState>({ status: 'loading' })
@@ -159,17 +126,17 @@ export function UnitModelViewer({
     }
   }, [main, highlight])
 
-  // Persist colour changes globally so the choice carries across units.
+  // Persist against the current faction so the choice carries across its units.
   const setMainColor = (value: string) => {
     setMain(value)
-    writeColorPref({ main: value, highlight })
+    writeTeamColorPref({ main: value, highlight, factionId })
   }
   const setHighlightColor = (value: string) => {
     setHighlight(value)
-    writeColorPref({ main, highlight: value })
+    writeTeamColorPref({ main, highlight: value, factionId })
   }
   const resetToFactionDefault = () => {
-    clearColorPref()
+    clearTeamColorPref()
     setMain(factionDefault.primary)
     setHighlight(factionDefault.secondary)
   }
@@ -196,11 +163,12 @@ export function UnitModelViewer({
       try {
         model = await loadUnitModel(factionId, unitId, version)
       } catch (err) {
+        // Generic on purpose: this error can carry internal URLs and stack text
+        // (network / range / zip failures). The detail goes to the console for
+        // developers, never to the panel.
+        console.warn('Failed to load unit model', err)
         if (!cancelled) {
-          setLoadState({
-            status: 'error',
-            message: err instanceof Error ? err.message : 'Failed to load model',
-          })
+          setLoadState({ status: 'error', message: 'Could not load this model. Try reloading.' })
         }
         return
       }

--- a/web/src/components/__tests__/UnitModelSection.test.tsx
+++ b/web/src/components/__tests__/UnitModelSection.test.tsx
@@ -60,32 +60,125 @@ describe('UnitModelSection — trigger + modal', () => {
     expect(screen.queryByTestId('model-modal')).toBeNull()
   })
 
-  it('renders nothing when the unit has no model in the index', async () => {
-    mockGetIndex.mockResolvedValue(indexWith('other_unit'))
-    const { container } = render(<UnitModelSection factionId="MLA" unitId="radar" />)
-    await waitFor(() => expect(mockGetIndex).toHaveBeenCalled())
-    expect(screen.queryByTestId('view-3d-model')).toBeNull()
-    expect(container).toBeEmptyDOMElement()
-  })
-
-  it('renders nothing when the faction has no model bundle (null index)', async () => {
-    mockGetIndex.mockResolvedValue(null)
-    const { container } = render(<UnitModelSection factionId="MLA" unitId="radar" />)
-    await waitFor(() => expect(mockGetIndex).toHaveBeenCalled())
-    expect(container).toBeEmptyDOMElement()
-  })
-
-  it('renders nothing (no crash) when availability lookup rejects', async () => {
-    mockGetIndex.mockRejectedValue(new Error('network'))
-    const { container } = render(<UnitModelSection factionId="MLA" unitId="radar" />)
-    await waitFor(() => expect(mockGetIndex).toHaveBeenCalled())
-    expect(container).toBeEmptyDOMElement()
-  })
-
   it('passes the version through to the availability lookup', async () => {
     mockGetIndex.mockResolvedValue(indexWith('radar'))
     render(<UnitModelSection factionId="MLA" unitId="radar" version="1.0.0" />)
     await screen.findByTestId('view-3d-model')
     expect(mockGetIndex).toHaveBeenCalledWith('MLA', '1.0.0')
+  })
+})
+
+describe('UnitModelSection — unavailable state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // Each of these means the unit genuinely HAS no model, by a different route.
+  // A failed lookup is deliberately not in this list — see the error suite.
+  const unavailableCases: Array<[string, () => void]> = [
+    ['the unit is absent from the index', () => mockGetIndex.mockResolvedValue(indexWith('other'))],
+    ['the faction has no model bundle', () => mockGetIndex.mockResolvedValue(null)],
+  ]
+
+  it.each(unavailableCases)('shows a disabled button with a tooltip when %s', async (_label, arrange) => {
+    arrange()
+    render(<UnitModelSection factionId="MLA" unitId="radar" />)
+
+    const button = await screen.findByTestId('view-3d-model')
+    expect(button).toHaveAttribute('aria-disabled', 'true')
+    expect(button).toHaveAttribute('title', expect.stringContaining('No 3D model is available'))
+  })
+
+  it('does not open the modal when the disabled button is clicked', async () => {
+    mockGetIndex.mockResolvedValue(null)
+    render(<UnitModelSection factionId="MLA" unitId="radar" />)
+
+    await userEvent.click(await screen.findByTestId('view-3d-model'))
+    expect(screen.queryByTestId('model-modal')).toBeNull()
+  })
+
+  // aria-disabled (rather than the disabled attribute) is load-bearing: a truly
+  // disabled button suppresses pointer events, so the title tooltip explaining
+  // the absence would never appear — which is the whole point of showing it.
+  it('stays hoverable and focusable so the tooltip is reachable', async () => {
+    mockGetIndex.mockResolvedValue(null)
+    render(<UnitModelSection factionId="MLA" unitId="radar" />)
+
+    const button = await screen.findByTestId('view-3d-model')
+    expect(button).not.toBeDisabled()
+    await userEvent.tab()
+    expect(button).toHaveFocus()
+  })
+})
+
+describe('UnitModelSection — failed lookup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // The distinction that matters: a failed check must not claim the model is
+  // absent. The models may well exist — we simply could not find out.
+  it('says it could not check, NOT that no model exists', async () => {
+    mockGetIndex.mockRejectedValue(new Error('network'))
+    render(<UnitModelSection factionId="MLA" unitId="radar" />)
+
+    const button = await screen.findByTestId('view-3d-model')
+    expect(button).toHaveAttribute('data-state', 'error')
+    expect(button).toHaveAttribute('title', "Couldn't check for a 3D model. Try reloading the page.")
+    expect(button.getAttribute('title')).not.toMatch(/No 3D model is available/)
+  })
+
+  it('never surfaces the underlying error detail', async () => {
+    mockGetIndex.mockRejectedValue(
+      new Error('connect ECONNREFUSED 10.0.0.1:443 /internal/bundle.zip')
+    )
+    const { container } = render(<UnitModelSection factionId="MLA" unitId="radar" />)
+
+    const button = await screen.findByTestId('view-3d-model')
+    expect(button.getAttribute('title')).not.toMatch(/ECONNREFUSED|10\.0\.0\.1|internal|\.zip/i)
+    expect(container.textContent).not.toMatch(/ECONNREFUSED|10\.0\.0\.1|internal/i)
+  })
+
+  it('is still disabled and inert', async () => {
+    mockGetIndex.mockRejectedValue(new Error('network'))
+    render(<UnitModelSection factionId="MLA" unitId="radar" />)
+
+    const button = await screen.findByTestId('view-3d-model')
+    expect(button).toHaveAttribute('aria-disabled', 'true')
+    await userEvent.click(button)
+    expect(screen.queryByTestId('model-modal')).toBeNull()
+  })
+
+  it('marks a genuine absence as such, not as an error', async () => {
+    mockGetIndex.mockResolvedValue(null)
+    render(<UnitModelSection factionId="MLA" unitId="radar" />)
+
+    expect(await screen.findByTestId('view-3d-model')).toHaveAttribute('data-state', 'none')
+  })
+})
+
+describe('UnitModelSection — checking state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows a disabled loading button while availability is in flight', async () => {
+    // A promise we never resolve, pinning the component in the checking state.
+    mockGetIndex.mockReturnValue(new Promise(() => {}))
+    render(<UnitModelSection factionId="MLA" unitId="radar" />)
+
+    const button = screen.getByTestId('view-3d-model-checking')
+    expect(button).toBeDisabled()
+    expect(button).toHaveTextContent(/checking/i)
+    // Not yet the real trigger, and no tooltip claiming the model is missing.
+    expect(screen.queryByTestId('view-3d-model')).toBeNull()
+  })
+
+  it('replaces the loading button with the real trigger once available', async () => {
+    mockGetIndex.mockResolvedValue(indexWith('radar'))
+    render(<UnitModelSection factionId="MLA" unitId="radar" />)
+
+    expect(await screen.findByTestId('view-3d-model')).toBeEnabled()
+    await waitFor(() => expect(screen.queryByTestId('view-3d-model-checking')).toBeNull())
   })
 })

--- a/web/src/services/__tests__/modelLoader.test.ts
+++ b/web/src/services/__tests__/modelLoader.test.ts
@@ -9,6 +9,7 @@ import {
 } from '@zip.js/zip.js'
 import {
   getFactionModelsIndex,
+  ModelIndexUnavailableError,
   loadUnitModel,
   clearModelCache,
   type ModelsIndex,
@@ -289,22 +290,39 @@ describe('modelLoader — production mode', () => {
   })
 
   it('getFactionModelsIndex never whole-bundle-downloads on page load when Range is unsupported', async () => {
-    // A CDN that ignores Range (200, no accept-ranges). The precheck must degrade
-    // to "no models" rather than downloading the entire bundle just to check.
+    // A CDN that ignores Range (200, no accept-ranges). The precheck must fail
+    // rather than download the entire bundle just to check.
     mockGetEntry.mockResolvedValue(modelsEntry())
     // CDN ignores Range: always 200 full body, no Accept-Ranges.
     global.fetch = vi.fn(async () =>
       new Response(bundleBytes.slice(0), { status: 200 })
     ) as unknown as typeof fetch
 
-    const index = await getFactionModelsIndex('MLA')
-    expect(index).toBeNull()
+    // The manifest says a bundle exists, so a failed read must NOT masquerade as
+    // "this faction has no models" — that would report absence for data that
+    // exists. It throws, and the UI turns that into "couldn't check".
+    await expect(getFactionModelsIndex('MLA')).rejects.toBeInstanceOf(ModelIndexUnavailableError)
+
     // Critically: nothing was cached as a whole bundle — the precheck did not
     // download the full bundle just to check availability.
     const db = await openDB('pa-pedia-model-cache', 1)
     const bundles = await db.getAll('bundles')
     db.close()
     expect(bundles.length).toBe(0)
+  })
+
+  it('does not leak the underlying cause in the error message', async () => {
+    mockGetEntry.mockResolvedValue(modelsEntry())
+    global.fetch = vi.fn(async () => {
+      throw new Error('connect ECONNREFUSED 10.0.0.1:443 while fetching /internal/path.zip')
+    }) as unknown as typeof fetch
+
+    const error = await getFactionModelsIndex('MLA').catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(ModelIndexUnavailableError)
+    // The message is a fixed string; internals are reachable only via `cause`
+    // (for console diagnostics), never via the message the UI might render.
+    expect((error as Error).message).toBe('model index unavailable')
+    expect((error as Error).message).not.toMatch(/ECONNREFUSED|10\.0\.0\.1|internal/i)
   })
 
   it('loads a unit model as blob URLs and caches per-unit', async () => {

--- a/web/src/services/__tests__/teamColorPref.test.ts
+++ b/web/src/services/__tests__/teamColorPref.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { readTeamColorPref, writeTeamColorPref, clearTeamColorPref } from '../teamColorPref'
+
+const KEY = 'pa-pedia-team-colors'
+const PURPLE = { main: '#8b5cf6', highlight: '#c4b5fd' }
+
+describe('teamColorPref', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns colours picked for the same faction', () => {
+    writeTeamColorPref({ ...PURPLE, factionId: 'MLA' })
+    expect(readTeamColorPref('MLA')).toEqual({ ...PURPLE, factionId: 'MLA' })
+  })
+
+  // The core of the fix: a pick on one faction must not seed another.
+  it('returns null for a different faction', () => {
+    writeTeamColorPref({ ...PURPLE, factionId: 'MLA' })
+    expect(readTeamColorPref('Legion')).toBeNull()
+  })
+
+  it('is case-sensitive about the faction id', () => {
+    writeTeamColorPref({ ...PURPLE, factionId: 'MLA' })
+    expect(readTeamColorPref('mla')).toBeNull()
+  })
+
+  it('returns null when nothing is stored', () => {
+    expect(readTeamColorPref('MLA')).toBeNull()
+  })
+
+  it('lets a later pick take over the single slot', () => {
+    writeTeamColorPref({ ...PURPLE, factionId: 'MLA' })
+    writeTeamColorPref({ main: '#ff0000', highlight: '#00ff00', factionId: 'Legion' })
+
+    expect(readTeamColorPref('Legion')).toEqual({
+      main: '#ff0000',
+      highlight: '#00ff00',
+      factionId: 'Legion',
+    })
+    // MLA's earlier pick is gone — one slot, not a per-faction history.
+    expect(readTeamColorPref('MLA')).toBeNull()
+  })
+
+  it('clears the stored preference', () => {
+    writeTeamColorPref({ ...PURPLE, factionId: 'MLA' })
+    clearTeamColorPref()
+    expect(readTeamColorPref('MLA')).toBeNull()
+  })
+
+  describe('malformed storage', () => {
+    // A pref written by a build predating faction stamping. It must miss rather
+    // than throw, so users silently fall back to faction defaults on upgrade.
+    it('ignores a legacy pref with no factionId', () => {
+      localStorage.setItem(KEY, JSON.stringify(PURPLE))
+      expect(readTeamColorPref('MLA')).toBeNull()
+    })
+
+    it('ignores unparseable JSON', () => {
+      localStorage.setItem(KEY, 'not json{')
+      expect(readTeamColorPref('MLA')).toBeNull()
+    })
+
+    it.each([
+      ['wrong-typed fields', JSON.stringify({ main: 1, highlight: 2, factionId: 'MLA' })],
+      ['null', JSON.stringify(null)],
+      ['an array', JSON.stringify([])],
+    ])('ignores %s', (_label, raw) => {
+      localStorage.setItem(KEY, raw)
+      expect(readTeamColorPref('MLA')).toBeNull()
+    })
+  })
+
+  describe('unavailable storage', () => {
+    it('reads as no-preference when localStorage throws', () => {
+      vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+        throw new Error('SecurityError')
+      })
+      expect(readTeamColorPref('MLA')).toBeNull()
+    })
+
+    it('swallows write failures (quota / private mode)', () => {
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('QuotaExceededError')
+      })
+      expect(() => writeTeamColorPref({ ...PURPLE, factionId: 'MLA' })).not.toThrow()
+    })
+
+    it('swallows clear failures', () => {
+      vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+        throw new Error('SecurityError')
+      })
+      expect(() => clearTeamColorPref()).not.toThrow()
+    })
+  })
+})

--- a/web/src/services/modelLoader.ts
+++ b/web/src/services/modelLoader.ts
@@ -327,16 +327,45 @@ async function extractEntries(
 // ---------------------------------------------------------------------------
 
 /**
+ * Raised when the model index could not be READ — network failure, unusable
+ * Range support, or a bundle missing its own `models.json`.
+ *
+ * Kept strictly apart from a `null` return, which means the faction genuinely
+ * HAS no bundle. Callers must not conflate them: absence is normal and permanent
+ * ("no 3D model for this unit"), a failure is transient and reporting it as
+ * absence tells the user something false about data that does exist.
+ *
+ * `cause` is for console diagnostics only — never render it, it can carry
+ * internal URLs and stack text.
+ */
+export class ModelIndexUnavailableError extends Error {
+  constructor(cause: unknown) {
+    super('model index unavailable')
+    this.name = 'ModelIndexUnavailableError'
+    this.cause = cause
+  }
+}
+
+/**
  * Resolve whether a model bundle exists for a faction+version and return its
- * availability index (`models.json`). Returns `null` when there is no bundle
- * (the common backfill case) — with no failed network request in production,
- * since the manifest tells us up front.
+ * availability index (`models.json`).
+ *
+ * Returns `null` when there is no bundle (the common backfill case) — with no
+ * failed network request in production, since the manifest tells us up front.
+ * Throws {@link ModelIndexUnavailableError} when a bundle exists but its index
+ * could not be read.
  */
 export async function getFactionModelsIndex(
   factionId: string,
   version?: string | null
 ): Promise<ModelsIndex | null> {
   // Dev: fetch the unzipped models.json directly. Missing file → no models.
+  //
+  // Any failure here is absence, not an error: a faction with no local models
+  // has no file for the middleware to serve, so the request falls through to
+  // vite's SPA fallback and returns index.html — which fails to parse as JSON.
+  // That is the normal "I only have MLA models checked out" case, so it must
+  // read as "no model", not as a scary error on every other faction.
   if (isDevLocalModels()) {
     try {
       const response = await fetch(`${MODELS_BASE_PATH}/${factionId}/models.json`)
@@ -371,8 +400,8 @@ export async function getFactionModelsIndex(
   // Cache miss / stale — read models.json via a RANGE request only. This runs
   // on unit-page load (to decide whether to show the "View 3D Model" button), so
   // it must never download the whole multi-MB bundle. The whole-bundle fallback
-  // is therefore disabled here; if Range is unavailable we treat the faction as
-  // having no viewable models this session (graceful — no button, no big fetch).
+  // is therefore disabled here; if Range is unavailable we fail this read rather
+  // than pull megabytes just to answer "is there a model?".
   // The actual model download (loadUnitModel) keeps the fallback, since that only
   // runs after the user clicks.
   const url = modelBundleUrl(manifestEntry.models)
@@ -387,10 +416,14 @@ export async function getFactionModelsIndex(
     )
     bytes = extracted.get('models.json')
   } catch (error) {
-    console.warn('Model index unavailable without a whole-bundle download; hiding 3D viewer', error)
-    return null
+    // The manifest told us a bundle exists, so this is a failure to read it —
+    // never absence. Detail stays in the console for developers; callers show a
+    // generic message so internals never reach the UI.
+    console.warn('Model index unavailable without a whole-bundle download', error)
+    throw new ModelIndexUnavailableError(error)
   }
-  if (!bytes) return null
+  // A bundle without its own index is corrupt, not empty.
+  if (!bytes) throw new ModelIndexUnavailableError('models.json missing from bundle')
 
   const index = JSON.parse(new TextDecoder().decode(bytes)) as ModelsIndex
   await db.put('indexes', {

--- a/web/src/services/modelLoader.ts
+++ b/web/src/services/modelLoader.ts
@@ -38,7 +38,7 @@ import {
   getManifestEntry,
   getManifestVersion,
   isDevelopmentMode,
-  getSiteBaseUrl,
+  type ModelBundleInfo,
 } from './manifestLoader'
 
 // Run zip decompression inline (no web workers). Bundle entries are already
@@ -81,6 +81,24 @@ export interface LoadedUnitModel {
 }
 
 const MODELS_BASE_PATH = `${import.meta.env.BASE_URL}faction-models`
+
+/**
+ * URL of a faction's model bundle zip.
+ *
+ * Deliberately RELATIVE, unlike faction data (which dev-live fetches straight
+ * from the production origin via `getSiteBaseUrl`). We read these bundles with
+ * Range requests to pull one unit out of a large zip, and `Range` is not a
+ * CORS-safelisted header — so fetching cross-origin makes the browser preflight,
+ * and the /faction-models Pages Function answers only GET/HEAD with no CORS
+ * headers (it is same-origin in prod, so it never needs them). The preflight
+ * fails and the viewer concludes there are no models.
+ *
+ * Staying relative keeps the browser same-origin in every mode: prod hits the
+ * Pages Function directly, dev-live goes through the vite proxy (vite.config.ts).
+ */
+function modelBundleUrl(models: ModelBundleInfo): string {
+  return models.downloadUrl
+}
 
 /**
  * Dev-local mode: dev server without live production data. In this mode model
@@ -357,7 +375,7 @@ export async function getFactionModelsIndex(
   // having no viewable models this session (graceful — no button, no big fetch).
   // The actual model download (loadUnitModel) keeps the fallback, since that only
   // runs after the user clicks.
-  const url = getSiteBaseUrl() + manifestEntry.models.downloadUrl
+  const url = modelBundleUrl(manifestEntry.models)
   let bytes: Uint8Array | undefined
   try {
     const extracted = await extractEntries(
@@ -478,7 +496,7 @@ export async function loadUnitModel(
     if (entry.mask) names.push(entry.mask)
     if (entry.material) names.push(entry.material)
 
-    const url = getSiteBaseUrl() + manifestEntry.models.downloadUrl
+    const url = modelBundleUrl(manifestEntry.models)
     const extracted = await extractEntries(url, bundleKey, bundleStamp, names)
 
     // Copy each entry into a fresh ArrayBuffer that owns exactly its bytes.

--- a/web/src/services/teamColorPref.ts
+++ b/web/src/services/teamColorPref.ts
@@ -1,0 +1,69 @@
+/**
+ * teamColorPref
+ *
+ * Persistence for the 3D viewer's team-colour pickers.
+ *
+ * The preference is a single global slot stamped with the faction it was chosen
+ * for. Reads only hand it back for a matching faction, so a colour picked on one
+ * faction carries across that faction's units (and page reloads) but never
+ * bleeds into another faction — landing on a new faction shows its own default
+ * colours. Picking a colour there takes over the slot; there is deliberately no
+ * per-faction history.
+ */
+
+const COLOR_PREF_KEY = 'pa-pedia-team-colors'
+
+export interface TeamColorPref {
+  main: string
+  highlight: string
+  /** Faction the colours were chosen for; a read against any other faction misses. */
+  factionId: string
+}
+
+function isValidPref(value: unknown): value is TeamColorPref {
+  const pref = value as Partial<TeamColorPref> | null
+  return (
+    !!pref &&
+    typeof pref.main === 'string' &&
+    typeof pref.highlight === 'string' &&
+    typeof pref.factionId === 'string'
+  )
+}
+
+/**
+ * The stored colours, but only if they were chosen for `factionId`.
+ *
+ * Returns null for a different faction, no stored pref, or a pref written by an
+ * older build (which had no factionId) — all of which mean "use the faction
+ * default", so the legacy format needs no migration.
+ */
+export function readTeamColorPref(factionId: string): TeamColorPref | null {
+  try {
+    const raw = localStorage.getItem(COLOR_PREF_KEY)
+    if (!raw) return null
+    const parsed: unknown = JSON.parse(raw)
+    if (!isValidPref(parsed)) return null
+    return parsed.factionId === factionId ? parsed : null
+  } catch {
+    // Corrupt JSON / unavailable storage → treat as no preference.
+    return null
+  }
+}
+
+/** Persist the colours against their faction, replacing any previous slot. */
+export function writeTeamColorPref(pref: TeamColorPref): void {
+  try {
+    localStorage.setItem(COLOR_PREF_KEY, JSON.stringify(pref))
+  } catch {
+    // Ignore storage failures (private mode / quota).
+  }
+}
+
+/** Drop the stored preference, so viewers fall back to faction defaults. */
+export function clearTeamColorPref(): void {
+  try {
+    localStorage.removeItem(COLOR_PREF_KEY)
+  } catch {
+    // Ignore.
+  }
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -173,6 +173,12 @@ function devContentType(ext: string): string {
   return contentTypes[ext] || 'application/octet-stream'
 }
 
+/** `just dev-live`: dev server backed by real production faction data. */
+const DEV_LIVE = process.env.VITE_USE_LIVE_DATA === 'true'
+
+/** Production origin that dev-live borrows faction + model data from. */
+const PRODUCTION_ORIGIN = 'https://pa-pedia.com'
+
 /**
  * Custom plugin to serve /faction-models from the repo-root faction-models/ dir.
  *
@@ -185,6 +191,9 @@ function devContentType(ext: string): string {
  *
  * Kept separate from /factions so the faction-data zip workflow is untouched.
  * Can be overridden via VITE_FACTION_MODELS_DIR (e.g. for E2E fixtures).
+ *
+ * Skipped in dev-live, where model bundles come from production via the proxy
+ * below rather than from local files (see DEV_LIVE).
  */
 function serveFactionModels(): Plugin {
   const modelsDir = path.resolve(__dirname, process.env.VITE_FACTION_MODELS_DIR || '../faction-models')
@@ -192,6 +201,10 @@ function serveFactionModels(): Plugin {
   return {
     name: 'serve-faction-models',
     configureServer(server) {
+      // dev-live serves these from production through the proxy; local files
+      // must not shadow it.
+      if (DEV_LIVE) return
+
       server.middlewares.use('/faction-models', (req, res, next) => {
         const reqUrl = req.url || ''
         const filePath = path.join(modelsDir, reqUrl.split('?')[0])
@@ -224,5 +237,22 @@ export default defineConfig({
       // Allow serving files from the factions folder at repo root
       allow: ['..'],
     },
+    // dev-live reads model bundles from production. Fetching them cross-origin
+    // does not work: zip.js sends a Range header to read a single unit out of
+    // the bundle, Range is not CORS-safelisted, so the browser preflights — and
+    // the Cloudflare Pages Function that serves /faction-models only answers
+    // GET/HEAD and sets no CORS headers (it is same-origin in prod, so it never
+    // needs them). The preflight fails and the 3D viewer sees "no models".
+    //
+    // Proxying here keeps the browser same-origin, exactly as in production, so
+    // no CORS is involved and production needs no dev-only concessions.
+    ...(DEV_LIVE && {
+      proxy: {
+        '/faction-models': {
+          target: PRODUCTION_ORIGIN,
+          changeOrigin: true,
+        },
+      },
+    }),
   },
 })


### PR DESCRIPTION
Stacked on #434 — please merge that first; this PR targets it as its base and will retarget to `main` automatically.

Two pieces of viewer polish, plus the loader change the first one needs.

## 1. Explain why the button is unavailable

The "View 3D Model" button was hidden whenever a unit had no model, so its absence looked arbitrary. It's now always rendered, in one of four states:

| State | Render |
|---|---|
| `checking` | disabled, spinner + "Checking…" |
| `available` | live trigger (unchanged) |
| `none` | disabled — *"No 3D model is available for this unit at this version."* |
| `error` | disabled — *"Couldn't check for a 3D model. Try reloading the page."* |

**`aria-disabled`, not `disabled`** — this looks like a mistake, so it's commented in the code. A truly disabled button suppresses pointer events, so the `title` tooltip would never appear on hover, defeating the entire point. `aria-disabled` keeps it hoverable *and* focusable, so the reason also reaches keyboard users.

## 2. Absence and failure are not the same thing

`getFactionModelsIndex` swallowed read failures and returned `null` — the **same value** it returns when a faction genuinely has no bundle. So a failed lookup would have confidently claimed "no model exists" about data that does exist. (This is exactly what #434 diagnosed: every dev-live unit reported "no model" when the models were fine.)

It now throws `ModelIndexUnavailableError`; `null` means only genuine absence.

**No error details are surfaced.** The error message is a fixed string, with the cause attached for console diagnostics only. `UnitModelSection` doesn't even capture the error object. I also fixed a pre-existing leak this change would have fed: `UnitModelViewer` was rendering raw `err.message` into its error panel, which would have printed the new error's internals.

**Dev-local still treats any failure as absence, deliberately** — a faction with no local models falls through to vite's SPA fallback and returns HTML that fails to parse. That's the normal "only MLA checked out" case and must not show an error on every other faction.

## 3. Faction default colours

The team-colour preference was a single global localStorage key with no faction association, so a colour picked on one faction seeded every other faction's viewer.

It's now stamped with the faction it was chosen for and only honoured on a match: landing on a new faction shows **that faction's** defaults, while a pick still carries across its own units and reloads. Prefs from older builds have no `factionId`, fail the match, and fall back to defaults — no migration needed.

Extracted to `services/teamColorPref.ts` (self-contained, and testable without mounting WebGL). Also added `key={factionId}` to the viewer so a faction change re-seeds the pickers.

## Verification

Driven in a real browser against **live production data**, not just tests:

- All button states, including **blocking the network** to force a genuine failure and confirm it says "couldn't check", doesn't claim absence, and leaks no detail.
- Genuine absence (`tutorial_ai_commander_3`) still reports "no model".
- Colours: cross-faction reset, same-faction persistence, legacy-pref fallback, and reset-to-default.
- Confirmed the new split test genuinely fails when the split is reverted — a test that can't fail isn't worth having.

900 unit tests (up from 896), typecheck, and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
