### PR TITLE
feat(compare): detect raw source-file changes in "What's Changed"

### DIFF
--- a/web/src/components/VersionDiffModal.tsx
+++ b/web/src/components/VersionDiffModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useReducer } from 'react'
 import { Link } from 'react-router-dom'
 import { useFaction } from '@/hooks/useFaction'
 import { UnitIcon } from '@/components/UnitIcon'
@@ -7,8 +7,17 @@ import {
   hasChanges,
   type UnitRef,
   type ChangedUnit,
+  type VersionDiff,
 } from '@/utils/versionDiff'
-import type { FactionIndex } from '@/types/faction'
+import {
+  diffAssets,
+  groupAssetChanges,
+  type AssetChangeGroup,
+  type AssetFileChange,
+  type GroupedAssetChanges,
+} from '@/utils/assetDiff'
+import { loadFactionAssets } from '@/services/factionLoader'
+import type { FactionIndex, FactionMetadata } from '@/types/faction'
 
 interface VersionDiffModalProps {
   isOpen: boolean
@@ -18,8 +27,16 @@ interface VersionDiffModalProps {
   previousVersion: string
   /** Newer version being viewed (display label only). */
   currentVersion: string
+  /**
+   * Cache key of the version being viewed for asset lookup: the raw URL version
+   * (null = latest, stored unversioned). Distinct from {@link currentVersion},
+   * which is only the display label.
+   */
+  currentVersionKey: string | null
   /** Already-loaded index for the current version. */
   currentIndex: FactionIndex
+  /** Metadata for the current version, for the info (author/description) diff. */
+  currentMetadata?: FactionMetadata
 }
 
 /**
@@ -35,7 +52,9 @@ export function VersionDiffModal({
   factionId,
   previousVersion,
   currentVersion,
+  currentVersionKey,
   currentIndex,
+  currentMetadata,
 }: VersionDiffModalProps) {
   // Close on Escape while open
   useEffect(() => {
@@ -84,7 +103,9 @@ export function VersionDiffModal({
             factionId={factionId}
             previousVersion={previousVersion}
             currentVersion={currentVersion}
+            currentVersionKey={currentVersionKey}
             currentIndex={currentIndex}
+            currentMetadata={currentMetadata}
             onNavigate={onClose}
           />
         </div>
@@ -97,23 +118,132 @@ interface VersionDiffBodyProps {
   factionId: string
   previousVersion: string
   currentVersion: string
+  currentVersionKey: string | null
   currentIndex: FactionIndex
+  currentMetadata?: FactionMetadata
   onNavigate: () => void
+}
+
+/** Result of comparing the raw source-file trees of both versions. */
+interface RawDiff {
+  grouped: GroupedAssetChanges
+  metaChanges: string[]
+}
+
+type RawState =
+  | { phase: 'loading' }
+  | { phase: 'ready'; diff: RawDiff }
+  | { phase: 'unavailable' } // no cached asset maps (dev file mode / local)
+
+type RawAction = { type: 'RESET' } | { type: 'READY'; diff: RawDiff } | { type: 'UNAVAILABLE' }
+
+function rawReducer(_state: RawState, action: RawAction): RawState {
+  switch (action.type) {
+    case 'RESET':
+      return { phase: 'loading' }
+    case 'READY':
+      return { phase: 'ready', diff: action.diff }
+    case 'UNAVAILABLE':
+      return { phase: 'unavailable' }
+  }
+}
+
+/** UnitRef for every current-version unit, keyed by identifier (icons/links/names). */
+function buildUnitRefs(index: FactionIndex): Map<string, UnitRef> {
+  const map = new Map<string, UnitRef>()
+  for (const entry of index.units) {
+    map.set(entry.identifier, {
+      identifier: entry.identifier,
+      displayName: entry.displayName || entry.unit?.displayName || entry.identifier,
+      image: entry.unit?.image,
+    })
+  }
+  return map
+}
+
+/** Identifiers already shown in the resolved diff, so raw changes don't duplicate them. */
+function resolvedUnitIds(diff: VersionDiff): Set<string> {
+  const ids = new Set<string>()
+  for (const u of diff.added) ids.add(u.identifier)
+  for (const u of diff.removed) ids.add(u.identifier)
+  for (const u of diff.changed) ids.add(u.identifier)
+  return ids
+}
+
+/** Diff faction-level metadata (author/description). Version is the title, not a change. */
+function diffMetadata(prev?: FactionMetadata, curr?: FactionMetadata): string[] {
+  if (!prev || !curr) return []
+  const out: string[] = []
+  if (prev.author !== curr.author) {
+    out.push(`Author: "${prev.author ?? '–'}" → "${curr.author ?? '–'}"`)
+  }
+  if (prev.description !== curr.description) out.push('Description updated')
+  return out
 }
 
 function VersionDiffBody({
   factionId,
   previousVersion,
   currentVersion,
+  currentVersionKey,
   currentIndex,
+  currentMetadata,
   onNavigate,
 }: VersionDiffBodyProps) {
-  const { index: previousIndex, loading, error, retry } = useFaction(factionId, previousVersion)
+  const { index: previousIndex, metadata: previousMetadata, loading, error, retry } = useFaction(
+    factionId,
+    previousVersion
+  )
 
   const diff = useMemo(() => {
     if (!previousIndex) return null
     return diffFactionVersions(previousIndex, currentIndex, previousVersion, currentVersion)
   }, [previousIndex, currentIndex, previousVersion, currentVersion])
+
+  const [rawState, dispatch] = useReducer(rawReducer, { phase: 'loading' })
+
+  // Compare the raw source-file trees once the resolved diff is available. This is
+  // what catches changes invisible to units.json (ammo fields, icons, …).
+  useEffect(() => {
+    if (!diff) return
+    let cancelled = false
+    dispatch({ type: 'RESET' })
+
+    ;(async () => {
+      try {
+        const [prevAssets, currAssets] = await Promise.all([
+          loadFactionAssets(factionId, false, previousVersion),
+          loadFactionAssets(factionId, false, currentVersionKey),
+        ])
+        const metaChanges = diffMetadata(previousMetadata, currentMetadata)
+
+        if (!prevAssets || !currAssets) {
+          // No cached file trees (e.g. dev file mode). Metadata may still differ.
+          if (cancelled) return
+          if (metaChanges.length > 0) {
+            dispatch({
+              type: 'READY',
+              diff: { grouped: { groups: [], changedFileCount: 0 }, metaChanges },
+            })
+          } else {
+            dispatch({ type: 'UNAVAILABLE' })
+          }
+          return
+        }
+
+        const fileChanges = await diffAssets(prevAssets, currAssets)
+        const grouped = groupAssetChanges(fileChanges, resolvedUnitIds(diff), buildUnitRefs(currentIndex))
+        if (!cancelled) dispatch({ type: 'READY', diff: { grouped, metaChanges } })
+      } catch (err) {
+        console.error('Failed to compare source files for version diff:', err)
+        if (!cancelled) dispatch({ type: 'UNAVAILABLE' })
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [diff, factionId, previousVersion, currentVersionKey, currentIndex, previousMetadata, currentMetadata])
 
   if (error) {
     return (
@@ -139,10 +269,35 @@ function VersionDiffBody({
     )
   }
 
-  if (!hasChanges(diff)) {
+  const resolvedHas = hasChanges(diff)
+  const rawReady = rawState.phase === 'ready' ? rawState.diff : null
+  const hasOther =
+    !!rawReady && (rawReady.grouped.changedFileCount > 0 || rawReady.metaChanges.length > 0)
+
+  // Fallback: only claim "version bump only" once the source comparison has finished
+  // and found nothing on either side.
+  if (!resolvedHas && !hasOther) {
+    if (rawState.phase === 'loading') {
+      return (
+        <div className="flex items-center justify-center py-12 text-muted-foreground">
+          Analysing source files…
+        </div>
+      )
+    }
+    if (rawState.phase === 'unavailable') {
+      return (
+        <div className="text-center py-12 text-muted-foreground">
+          No tracked changes between v{previousVersion} and v{currentVersion}.
+        </div>
+      )
+    }
     return (
       <div className="text-center py-12 text-muted-foreground">
-        No tracked changes between v{previousVersion} and v{currentVersion}.
+        <p className="font-semibold text-foreground mb-1">Version-number bump only.</p>
+        <p className="text-sm">
+          The version changed from v{previousVersion} to v{currentVersion}, but nothing in the
+          extracted faction data did.
+        </p>
       </div>
     )
   }
@@ -183,6 +338,19 @@ function VersionDiffBody({
             <UnitRow key={unit.identifier} factionId={factionId} unit={unit} onNavigate={onNavigate} linkable={false} />
           ))}
         </DiffSection>
+      )}
+
+      {rawState.phase === 'loading' && (
+        <p className="text-xs text-muted-foreground italic">Analysing source files…</p>
+      )}
+
+      {hasOther && rawReady && (
+        <OtherChangesSection
+          factionId={factionId}
+          grouped={rawReady.grouped}
+          metaChanges={rawReady.metaChanges}
+          onNavigate={onNavigate}
+        />
       )}
     </div>
   )
@@ -264,6 +432,107 @@ function ChangedUnitRow({ factionId, unit, onNavigate }: ChangedUnitRowProps) {
         {unit.fields.map((field) => (
           <li key={field.label} className="text-xs font-mono text-muted-foreground">
             {field.display}
+          </li>
+        ))}
+      </ul>
+    </li>
+  )
+}
+
+interface OtherChangesSectionProps {
+  factionId: string
+  grouped: GroupedAssetChanges
+  metaChanges: string[]
+  onNavigate: () => void
+}
+
+/**
+ * Secondary, technical section for changes that don't surface as resolved unit
+ * stats — raw source-file edits (verbatim PA field names), icon changes, and
+ * faction-info edits. Deliberately muted so the balance sections stay prominent.
+ */
+function OtherChangesSection({ factionId, grouped, metaChanges, onNavigate }: OtherChangesSectionProps) {
+  const count = grouped.changedFileCount + (metaChanges.length > 0 ? 1 : 0)
+  return (
+    <section className="border-t border-gray-200 dark:border-gray-700 pt-4">
+      <h3 className="text-xs font-semibold uppercase tracking-wide mb-1 text-muted-foreground">
+        Other changes ({count})
+      </h3>
+      <p className="text-xs text-muted-foreground mb-2">
+        Source-level edits not reflected in unit stats (raw PA field names).
+      </p>
+      <ul className="space-y-2">
+        {metaChanges.length > 0 && (
+          <li className="bg-muted/40 rounded-md p-2">
+            <span className="text-sm font-semibold">Faction info</span>
+            <ul className="mt-1 ml-2 list-disc list-inside space-y-0.5">
+              {metaChanges.map((line) => (
+                <li key={line} className="text-xs font-mono text-muted-foreground">
+                  {line}
+                </li>
+              ))}
+            </ul>
+          </li>
+        )}
+        {grouped.groups.map((group) => (
+          <OtherChangeGroup key={group.key} factionId={factionId} group={group} onNavigate={onNavigate} />
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+function fileStatusLabel(file: AssetFileChange): string {
+  if (file.status === 'added') return `${file.name} (added)`
+  if (file.status === 'removed') return `${file.name} (removed)`
+  return file.name
+}
+
+function OtherChangeGroup({
+  factionId,
+  group,
+  onNavigate,
+}: {
+  factionId: string
+  group: AssetChangeGroup
+  onNavigate: () => void
+}) {
+  const heading = group.ref ? (
+    <Link
+      to={`/faction/${factionId}/unit/${group.ref.identifier}`}
+      onClick={onNavigate}
+      className="inline-flex items-center gap-2 hover:text-primary transition-colors"
+    >
+      <span className="w-7 h-7 flex-shrink-0 flex items-center justify-center bg-muted rounded">
+        <UnitIcon imagePath={group.ref.image} alt={group.label} className="w-6 h-6" factionId={factionId} />
+      </span>
+      <span className="text-sm font-semibold">{group.label}</span>
+    </Link>
+  ) : (
+    <span className="text-sm font-semibold">{group.label}</span>
+  )
+
+  return (
+    <li className="bg-muted/40 rounded-md p-2">
+      {heading}
+      <ul className="mt-1 ml-2 space-y-1">
+        {group.files.map((file) => (
+          <li key={file.path}>
+            <span className="text-xs font-mono text-muted-foreground/80">{fileStatusLabel(file)}</span>
+            {file.lines.length > 0 && (
+              <ul className="ml-3 list-disc list-inside space-y-0.5">
+                {file.lines.map((line, i) => (
+                  <li key={i} className="text-xs font-mono text-muted-foreground">
+                    {line}
+                  </li>
+                ))}
+                {file.truncatedLines > 0 && (
+                  <li className="text-xs italic text-muted-foreground">
+                    …and {file.truncatedLines} more
+                  </li>
+                )}
+              </ul>
+            )}
           </li>
         ))}
       </ul>

--- a/web/src/components/__tests__/VersionDiffModal.test.tsx
+++ b/web/src/components/__tests__/VersionDiffModal.test.tsx
@@ -5,7 +5,15 @@ import { VersionDiffModal } from '../VersionDiffModal'
 import { CurrentFactionProvider } from '@/contexts/CurrentFactionContext'
 import { renderWithFactionProvider } from '@/tests/helpers'
 import { setupMockFetch, mockMLAIndex } from '@/tests/mocks/factionData'
-import type { FactionIndex } from '@/types/faction'
+import * as factionLoader from '@/services/factionLoader'
+import type { FactionIndex, FactionMetadata } from '@/types/faction'
+
+/** Build an asset map from path → string content, as loadFactionAssets returns. */
+function assetMap(entries: Record<string, string>): Map<string, Blob> {
+  const map = new Map<string, Blob>()
+  for (const [path, content] of Object.entries(entries)) map.set(path, new Blob([content]))
+  return map
+}
 
 /**
  * In standard test/dev mode a versioned index load ignores the version and serves
@@ -22,8 +30,15 @@ function renderModal(props: {
   currentIndex: FactionIndex
   previousVersion?: string
   currentVersion?: string
+  currentVersionKey?: string | null
+  currentMetadata?: FactionMetadata
 }) {
-  const { previousVersion = '0.9.0', currentVersion = '1.0.0', ...rest } = props
+  const {
+    previousVersion = '0.9.0',
+    currentVersion = '1.0.0',
+    currentVersionKey = null,
+    ...rest
+  } = props
   return renderWithFactionProvider(
     <BrowserRouter>
       <CurrentFactionProvider factionId="MLA">
@@ -31,6 +46,7 @@ function renderModal(props: {
           factionId="MLA"
           previousVersion={previousVersion}
           currentVersion={currentVersion}
+          currentVersionKey={currentVersionKey}
           {...rest}
         />
       </CurrentFactionProvider>
@@ -116,11 +132,40 @@ describe('VersionDiffModal', () => {
     expect(screen.getByText('Bot')).toBeInTheDocument()
   })
 
-  it('shows an empty state when nothing changed', async () => {
+  it('shows an empty state when source files are unavailable and nothing changed', async () => {
+    // Default test/dev mode: loadFactionAssets returns null (no cached file trees).
     renderModal({ isOpen: true, onClose: mockOnClose, currentIndex: cloneMLAIndex() })
 
     await waitFor(() => {
       expect(screen.getByText(/No tracked changes/i)).toBeInTheDocument()
+    })
+  })
+
+  it('surfaces raw source-file changes invisible to units.json', async () => {
+    const path = 'assets/pa/units/land/tank/tank_ammo.json'
+    vi.spyOn(factionLoader, 'loadFactionAssets')
+      .mockResolvedValueOnce(assetMap({ [path]: '{"collision_check":"Enemies"}' })) // previous
+      .mockResolvedValueOnce(assetMap({ [path]: '{"collision_check":"target"}' })) // current
+
+    renderModal({ isOpen: true, onClose: mockOnClose, currentIndex: cloneMLAIndex() })
+
+    await waitFor(() => {
+      expect(screen.getByText(/Other changes/i)).toBeInTheDocument()
+    })
+    expect(screen.getByText('collision_check: "Enemies" → "target"')).toBeInTheDocument()
+    expect(screen.queryByText(/No tracked changes/i)).not.toBeInTheDocument()
+  })
+
+  it('reports a version-number bump when nothing changed on either side', async () => {
+    const same = () => assetMap({ 'assets/pa/units/land/tank/tank.json': '{"x":1}' })
+    vi.spyOn(factionLoader, 'loadFactionAssets')
+      .mockResolvedValueOnce(same())
+      .mockResolvedValueOnce(same())
+
+    renderModal({ isOpen: true, onClose: mockOnClose, currentIndex: cloneMLAIndex() })
+
+    await waitFor(() => {
+      expect(screen.getByText(/Version-number bump only/i)).toBeInTheDocument()
     })
   })
 })

--- a/web/src/pages/FactionDetail.tsx
+++ b/web/src/pages/FactionDetail.tsx
@@ -599,7 +599,9 @@ export function FactionDetail() {
           factionId={factionId}
           previousVersion={previousVersion}
           currentVersion={currentVersionLabel}
+          currentVersionKey={version}
           currentIndex={singleFaction.index}
+          currentMetadata={metadata ?? undefined}
         />
       )}
 

--- a/web/src/services/factionLoader.ts
+++ b/web/src/services/factionLoader.ts
@@ -27,6 +27,7 @@ import {
   getStaticFactionCache,
   cacheStaticFaction,
   pruneStaleStaticFactions,
+  getAllStaticAssets,
 } from './staticFactionCache'
 import { getAssetUrl } from './assetUrlManager'
 
@@ -393,6 +394,40 @@ export async function loadFactionIndex(
   )
 
   return index
+}
+
+/**
+ * Loads the complete raw asset file tree for a faction version as a map keyed by
+ * asset path (e.g. "assets/pa/units/.../tank.json" -> Blob).
+ *
+ * Only cache-backed modes (production, dev-live) retain the raw files; plain dev
+ * (direct file fetch), dev-with-VITE_FACTIONS_DIR, and local factions have no
+ * asset map, so this returns null and callers degrade gracefully (no raw diff).
+ *
+ * Ensures the version is downloaded/cached first (via loadFactionIndex), then reads
+ * the assets straight from IndexedDB using the same cache key that stored them.
+ *
+ * @param version - Version to load (null = latest, keyed unversioned in the cache).
+ */
+export async function loadFactionAssets(
+  factionId: string,
+  isLocal: boolean = false,
+  version?: string | null
+): Promise<Map<string, Blob> | null> {
+  // Local factions and plain/custom-dir dev modes have no cached asset map.
+  if (isLocal) return null
+  if (isDevelopmentMode()) {
+    const useLiveData = import.meta.env.VITE_USE_LIVE_DATA === 'true'
+    if (!useLiveData) return null // plain dev or VITE_FACTIONS_DIR: no asset blobs cached
+  }
+
+  // Ensure the version is present in the cache (downloads + caches assets if missing).
+  await loadFactionIndex(factionId, isLocal, version)
+
+  const normalizedFactionId = factionId.toLowerCase()
+  const cacheKey = version ? `${normalizedFactionId}@${version}` : normalizedFactionId
+  const assets = await getAllStaticAssets(cacheKey)
+  return assets.size > 0 ? assets : null
 }
 
 /**

--- a/web/src/services/staticFactionCache.ts
+++ b/web/src/services/staticFactionCache.ts
@@ -154,6 +154,34 @@ export async function getStaticAsset(
 }
 
 /**
+ * Get every cached asset for a faction (or versioned faction) as a map keyed by
+ * the asset path (e.g. "assets/pa/units/...").
+ *
+ * Assets are stored under `${cacheKey}/${assetPath}`; we scan the key range for
+ * that prefix and strip it back off. Used by the version diff to compare the raw
+ * source file trees of two versions.
+ *
+ * @param cacheKey - The faction cache key: `${factionId}` (latest) or
+ *   `${factionId}@${version}`, matching the key used by cacheStaticFaction.
+ */
+export async function getAllStaticAssets(cacheKey: string): Promise<Map<string, Blob>> {
+  const db = await getDB()
+  const prefix = `${cacheKey}/`
+  // Range over all keys starting with the prefix. The '/' delimiter guarantees a
+  // versioned key (`id@ver/…`) or a longer id (`bugsX/…`) sorts outside this range,
+  // so we never pick up another faction's assets. '￿' is the largest BMP char.
+  const range = IDBKeyRange.bound(prefix, `${prefix}￿`, false, false)
+  const keys = (await db.getAllKeys('assets', range)) as string[]
+  const blobs = await db.getAll('assets', range)
+
+  const map = new Map<string, Blob>()
+  keys.forEach((key, i) => {
+    map.set(key.slice(prefix.length), blobs[i])
+  })
+  return map
+}
+
+/**
  * Delete a faction and all its assets from cache
  */
 export async function deleteStaticFactionCache(factionId: string): Promise<void> {

--- a/web/src/utils/__tests__/assetDiff.test.ts
+++ b/web/src/utils/__tests__/assetDiff.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest'
+import {
+  diffAssets,
+  groupAssetChanges,
+  unitIdFromPath,
+  type AssetFileChange,
+} from '../assetDiff'
+import type { UnitRef } from '../versionDiff'
+
+/** Build an asset map from a plain object of path → string/blob content. */
+function assets(entries: Record<string, string>): Map<string, Blob> {
+  const map = new Map<string, Blob>()
+  for (const [path, content] of Object.entries(entries)) {
+    map.set(path, new Blob([content]))
+  }
+  return map
+}
+
+const json = (obj: unknown) => JSON.stringify(obj, null, 2)
+
+describe('unitIdFromPath', () => {
+  it('extracts the owning unit folder for a unit file', () => {
+    expect(unitIdFromPath('assets/pa/units/land/tank/tank.json')).toBe('tank')
+  })
+
+  it('extracts the unit folder for a nested tool/ammo file', () => {
+    expect(unitIdFromPath('assets/pa/units/commanders/exiles_taurus/exiles_taurus_ammo.json')).toBe(
+      'exiles_taurus'
+    )
+  })
+
+  it('returns null for shared resources outside a unit folder', () => {
+    expect(unitIdFromPath('assets/pa/ammo/base_ammo.json')).toBeNull()
+    expect(unitIdFromPath('assets/pa/tools/base_tool.json')).toBeNull()
+  })
+})
+
+describe('diffAssets', () => {
+  it('surfaces a raw ammo field change with the verbatim PA field name', async () => {
+    // The real-world Exiles 0.7.4.2 → 0.7.4.3 case that currently shows "no changes".
+    const path = 'assets/pa/units/commanders/exiles_taurus/exiles_taurus_ammo.json'
+    const prev = assets({ [path]: json({ damage: 180, collision_check: 'Enemies' }) })
+    const curr = assets({ [path]: json({ damage: 180, collision_check: 'target' }) })
+
+    const changes = await diffAssets(prev, curr)
+
+    expect(changes).toHaveLength(1)
+    expect(changes[0].status).toBe('changed')
+    expect(changes[0].unitId).toBe('exiles_taurus')
+    expect(changes[0].lines).toEqual(['collision_check: "Enemies" → "target"'])
+  })
+
+  it('formats numeric changes with a percent delta', async () => {
+    const path = 'assets/pa/units/land/tank/tank_ammo.json'
+    const prev = assets({ [path]: json({ damage: 180 }) })
+    const curr = assets({ [path]: json({ damage: 150 }) })
+
+    const [change] = await diffAssets(prev, curr)
+    expect(change.lines).toEqual(['damage: 180 → 150 (-17%)'])
+  })
+
+  it('reports added and removed files', async () => {
+    const prev = assets({ 'assets/pa/units/land/a/a.json': json({ x: 1 }) })
+    const curr = assets({ 'assets/pa/units/land/b/b.json': json({ y: 2 }) })
+
+    const changes = await diffAssets(prev, curr)
+    const byStatus = Object.fromEntries(changes.map((c) => [c.status, c.name]))
+    expect(byStatus).toEqual({ removed: 'a.json', added: 'b.json' })
+  })
+
+  it('flags a changed binary icon without field detail', async () => {
+    const path = 'assets/pa/units/land/tank/tank_icon_buildbar.png'
+    const prev = assets({ [path]: 'PNGDATA-old' })
+    const curr = assets({ [path]: 'PNGDATA-new-longer' })
+
+    const [change] = await diffAssets(prev, curr)
+    expect(change.status).toBe('changed')
+    expect(change.lines).toEqual(['Icon changed'])
+  })
+
+  it('ignores whitespace-only JSON differences', async () => {
+    const path = 'assets/pa/units/land/tank/tank.json'
+    const prev = assets({ [path]: '{"damage":180}' })
+    const curr = assets({ [path]: '{\n  "damage": 180\n}' })
+
+    expect(await diffAssets(prev, curr)).toHaveLength(0)
+  })
+
+  it('ignores byte-identical binaries', async () => {
+    const path = 'assets/pa/units/land/tank/tank_icon_buildbar.png'
+    const prev = assets({ [path]: 'SAME' })
+    const curr = assets({ [path]: 'SAME' })
+    expect(await diffAssets(prev, curr)).toHaveLength(0)
+  })
+
+  it('handles a field changing between array and non-array without throwing', async () => {
+    // Regression: a raw field that flips array <-> scalar/object once crashed the
+    // whole diff (arr.every is not a function), swallowing every change.
+    const path = 'assets/pa/units/air/t/t.json'
+    const prev = assets({ [path]: json({ caps: 'ORDER_Attack', payload: [1, 2] }) })
+    const curr = assets({ [path]: json({ caps: ['ORDER_Attack'], payload: { count: 2 } }) })
+
+    const changes = await diffAssets(prev, curr)
+    expect(changes).toHaveLength(1)
+    expect(changes[0].status).toBe('changed')
+    expect(changes[0].lines.length).toBeGreaterThan(0)
+  })
+
+  it('reports array length changes (e.g. a weapon added)', async () => {
+    const path = 'assets/pa/units/land/tank/tank.json'
+    const prev = assets({ [path]: json({ weapons: [{ id: 'w1' }] }) })
+    const curr = assets({ [path]: json({ weapons: [{ id: 'w1' }, { id: 'w2' }] }) })
+
+    const [change] = await diffAssets(prev, curr)
+    expect(change.lines[0]).toBe('weapons: 1 → 2 items')
+  })
+})
+
+describe('groupAssetChanges', () => {
+  const file = (over: Partial<AssetFileChange>): AssetFileChange => ({
+    path: 'assets/pa/units/land/tank/tank.json',
+    name: 'tank.json',
+    unitId: 'tank',
+    status: 'changed',
+    lines: ['x: 1 → 2'],
+    truncatedLines: 0,
+    ...over,
+  })
+
+  it('groups by owning unit and attaches the unit ref for icon/link', () => {
+    const refs = new Map<string, UnitRef>([
+      ['tank', { identifier: 'tank', displayName: 'Tank', image: 'tank.png' }],
+    ])
+    const { groups, changedFileCount } = groupAssetChanges([file({})], new Set(), refs)
+
+    expect(changedFileCount).toBe(1)
+    expect(groups[0].label).toBe('Tank')
+    expect(groups[0].ref?.image).toBe('tank.png')
+  })
+
+  it('drops files whose unit already appears in the resolved diff', () => {
+    const { groups, changedFileCount } = groupAssetChanges([file({})], new Set(['tank']), new Map())
+    expect(changedFileCount).toBe(0)
+    expect(groups).toHaveLength(0)
+  })
+
+  it('collects unmapped files under "Shared files", sorted last', () => {
+    const shared = file({
+      path: 'assets/pa/ammo/base_ammo.json',
+      name: 'base_ammo.json',
+      unitId: null,
+    })
+    const { groups } = groupAssetChanges([shared, file({})], new Set(), new Map())
+    expect(groups.map((g) => g.label)).toEqual(['tank', 'Shared files'])
+  })
+})

--- a/web/src/utils/assetDiff.ts
+++ b/web/src/utils/assetDiff.ts
@@ -1,0 +1,264 @@
+/**
+ * Diffs the raw PA source-file trees of two faction versions.
+ *
+ * The high-signal, player-facing diff (weapon stats, economy, …) is computed from
+ * the resolved `units.json` by {@link module:versionDiff}. But `units.json` is a
+ * lossy projection: many upstream version bumps change raw source files (ammo
+ * fields like `collision_check`, tool tweaks, icons) that never reach the resolved
+ * stats, so the resolved diff honestly reports "nothing changed".
+ *
+ * This module fills that gap. It compares the raw `assets/pa/**` files that the
+ * web app already downloads and caches, surfacing ANY change as a secondary
+ * "Other changes" section. Because these are the mod's actual source files, field
+ * names are shown verbatim (snake_case, e.g. `collision_check`) rather than
+ * humanised — the audience for this section wants the technical truth.
+ */
+import { formatNumber } from '@/utils/groupAggregation'
+import type { UnitRef } from '@/utils/versionDiff'
+
+export type FileStatus = 'changed' | 'added' | 'removed'
+
+/** A single changed raw file, with pre-formatted field-change lines. */
+export interface AssetFileChange {
+  /** Full asset path, e.g. "assets/pa/units/land/tank/tank.json". */
+  path: string
+  /** Basename, e.g. "tank.json". */
+  name: string
+  /** Owning unit identifier parsed from the path, or null for shared files. */
+  unitId: string | null
+  status: FileStatus
+  /**
+   * Field-level change lines for a changed JSON file (verbatim PA field names).
+   * Empty for added/removed files and for binary files (status/label carried by
+   * `status` + a single summary line).
+   */
+  lines: string[]
+  /** Per-file lines suppressed by the cap (0 when nothing was dropped). */
+  truncatedLines: number
+}
+
+/** Max field-change lines shown per file before collapsing into "…and N more". */
+const MAX_LINES_PER_FILE = 12
+
+function basename(path: string): string {
+  return path.slice(path.lastIndexOf('/') + 1)
+}
+
+function isJsonPath(path: string): boolean {
+  return path.toLowerCase().endsWith('.json')
+}
+
+/**
+ * Owning unit identifier for an asset path: the immediate parent directory of a
+ * file living under `.../units/.../<unitDir>/<file>`. Shared resources (ammo,
+ * tools, effects that aren't inside a unit folder) return null.
+ */
+export function unitIdFromPath(path: string): string | null {
+  const m = path.match(/\/units\/(?:.*\/)?([^/]+)\/[^/]+$/)
+  return m ? m[1] : null
+}
+
+function quote(value: unknown): string {
+  if (value === undefined || value === null) return '–'
+  if (typeof value === 'number') return formatNumber(value)
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No'
+  const s = String(value)
+  return `"${s.length > 60 ? `${s.slice(0, 59)}…` : s}"`
+}
+
+/** Format one scalar change as "field: before → after (+x%)". */
+function formatScalar(path: string, before: unknown, after: unknown): string {
+  let display = `${path}: ${quote(before)} → ${quote(after)}`
+  if (typeof before === 'number' && typeof after === 'number' && before > 0) {
+    const pct = Math.round(((after - before) / before) * 100)
+    if (Math.abs(pct) >= 1) display += ` (${pct > 0 ? '+' : ''}${pct}%)`
+  }
+  return display
+}
+
+/**
+ * Recursively diff two parsed JSON values, appending change lines to `out`.
+ * Field names are kept verbatim; nested paths are dotted (`a.b`) and array
+ * elements indexed (`a[0].b`).
+ */
+function walkRaw(prev: unknown, curr: unknown, path: string, out: string[]): void {
+  const prevIsObj = prev !== null && typeof prev === 'object'
+  const currIsObj = curr !== null && typeof curr === 'object'
+
+  if (prevIsObj || currIsObj) {
+    if (Array.isArray(prev) || Array.isArray(curr)) {
+      // Only one side may be an array (a field changed type); coerce the other to
+      // [] so array handling never runs against a non-array value.
+      const p = Array.isArray(prev) ? prev : []
+      const c = Array.isArray(curr) ? curr : []
+      // Arrays of STRINGS → set difference (order-independent tags, e.g. target
+      // layers). Numeric arrays are positional (coordinates, offsets) so they fall
+      // through to index-wise comparison instead — "+0/−0" set output would read as
+      // signed zero and lose position.
+      const allStrings = (arr: unknown[]) => arr.length > 0 && arr.every((v) => typeof v === 'string')
+      if (allStrings(p) && allStrings(c)) {
+        const ps = new Set(p as string[])
+        const cs = new Set(c as string[])
+        const added = [...cs].filter((v) => !ps.has(v)).map((v) => `+${v}`)
+        const removed = [...ps].filter((v) => !cs.has(v)).map((v) => `−${v}`)
+        if (added.length || removed.length) out.push(`${path}: ${[...added, ...removed].join(', ')}`)
+        return
+      }
+      if (p.length !== c.length) out.push(`${path}: ${p.length} → ${c.length} items`)
+      const n = Math.max(p.length, c.length)
+      for (let i = 0; i < n; i++) walkRaw(p[i], c[i], `${path}[${i}]`, out)
+      return
+    }
+    const po = (prevIsObj ? prev : {}) as Record<string, unknown>
+    const co = (currIsObj ? curr : {}) as Record<string, unknown>
+    for (const key of new Set([...Object.keys(po), ...Object.keys(co)])) {
+      walkRaw(po[key], co[key], path ? `${path}.${key}` : key, out)
+    }
+    return
+  }
+
+  if (prev === undefined && curr === undefined) return
+  if (prev !== curr) out.push(formatScalar(path, prev, curr))
+}
+
+/** Byte-equality for two blobs (size check first, then contents). */
+async function blobsEqual(a: Blob, b: Blob): Promise<boolean> {
+  if (a.size !== b.size) return false
+  const [ba, bb] = await Promise.all([a.arrayBuffer(), b.arrayBuffer()])
+  const va = new Uint8Array(ba)
+  const vb = new Uint8Array(bb)
+  for (let i = 0; i < va.length; i++) {
+    if (va[i] !== vb[i]) return false
+  }
+  return true
+}
+
+function binaryLabel(path: string): string {
+  return path.toLowerCase().endsWith('.png') ? 'Icon changed' : 'File changed'
+}
+
+function cap(lines: string[]): { lines: string[]; truncatedLines: number } {
+  if (lines.length <= MAX_LINES_PER_FILE) return { lines, truncatedLines: 0 }
+  return {
+    lines: lines.slice(0, MAX_LINES_PER_FILE),
+    truncatedLines: lines.length - MAX_LINES_PER_FILE,
+  }
+}
+
+/**
+ * Compare two raw asset maps (path → Blob) and return every changed, added, or
+ * removed file. Files whose contents are byte-identical are omitted, as are JSON
+ * files that differ only in whitespace.
+ */
+export async function diffAssets(
+  prev: Map<string, Blob>,
+  curr: Map<string, Blob>
+): Promise<AssetFileChange[]> {
+  const out: AssetFileChange[] = []
+  const paths = new Set([...prev.keys(), ...curr.keys()])
+
+  for (const path of paths) {
+    const a = prev.get(path)
+    const b = curr.get(path)
+    const meta = { path, name: basename(path), unitId: unitIdFromPath(path) }
+
+    if (a && !b) {
+      out.push({ ...meta, status: 'removed', lines: [], truncatedLines: 0 })
+      continue
+    }
+    if (!a && b) {
+      out.push({ ...meta, status: 'added', lines: [], truncatedLines: 0 })
+      continue
+    }
+    if (!a || !b) continue
+
+    if (isJsonPath(path)) {
+      const [ta, tb] = await Promise.all([a.text(), b.text()])
+      if (ta === tb) continue
+      let pa: unknown
+      let pb: unknown
+      try {
+        pa = JSON.parse(ta)
+        pb = JSON.parse(tb)
+      } catch {
+        out.push({ ...meta, status: 'changed', lines: ['File changed'], truncatedLines: 0 })
+        continue
+      }
+      const changes: string[] = []
+      try {
+        walkRaw(pa, pb, '', changes)
+      } catch (err) {
+        // A single malformed/edge-case file must not sink the whole comparison;
+        // fall back to a file-level note so its change is still surfaced.
+        console.warn(`Field diff failed for ${path}, reporting file-level change:`, err)
+        out.push({ ...meta, status: 'changed', lines: ['File changed'], truncatedLines: 0 })
+        continue
+      }
+      if (changes.length === 0) continue // whitespace / key-order only
+      out.push({ ...meta, status: 'changed', ...cap(changes) })
+    } else {
+      if (await blobsEqual(a, b)) continue
+      out.push({ ...meta, status: 'changed', lines: [binaryLabel(path)], truncatedLines: 0 })
+    }
+  }
+
+  return out
+}
+
+/** A group of raw file changes, keyed by owning unit (or shared/other). */
+export interface AssetChangeGroup {
+  key: string
+  /** Present when the group maps to a known current unit (enables icon + link). */
+  ref?: UnitRef
+  label: string
+  files: AssetFileChange[]
+}
+
+export interface GroupedAssetChanges {
+  groups: AssetChangeGroup[]
+  changedFileCount: number
+}
+
+const SHARED_KEY = '__shared__'
+
+/**
+ * Group raw file changes for display: by owning unit, with unmapped/shared files
+ * collected under "Shared files". Files whose owning unit already appears in the
+ * resolved diff are dropped (`excludeUnitIds`) so the two sections don't overlap.
+ *
+ * @param unitRefs - Current-version units by identifier, for icons/links/names.
+ */
+export function groupAssetChanges(
+  files: AssetFileChange[],
+  excludeUnitIds: Set<string>,
+  unitRefs: Map<string, UnitRef>
+): GroupedAssetChanges {
+  const groups = new Map<string, AssetChangeGroup>()
+
+  for (const file of files) {
+    if (file.unitId && excludeUnitIds.has(file.unitId)) continue
+
+    const key = file.unitId ?? SHARED_KEY
+    let group = groups.get(key)
+    if (!group) {
+      const ref = file.unitId ? unitRefs.get(file.unitId) : undefined
+      const label = ref?.displayName ?? file.unitId ?? 'Shared files'
+      group = { key, ref, label, files: [] }
+      groups.set(key, group)
+    }
+    group.files.push(file)
+  }
+
+  const ordered = [...groups.values()].sort((a, b) => {
+    // Shared group always sorts last; otherwise alphabetical by label.
+    if (a.key === SHARED_KEY) return 1
+    if (b.key === SHARED_KEY) return -1
+    return a.label.localeCompare(b.label)
+  })
+  for (const group of ordered) {
+    group.files.sort((a, b) => a.name.localeCompare(b.name))
+  }
+
+  const changedFileCount = ordered.reduce((n, g) => n + g.files.length, 0)
+  return { groups: ordered, changedFileCount }
+}


### PR DESCRIPTION
## Problem

The **"What's Changed"** version diff was computed **only from the resolved `units.json`** — a lossy projection of a faction. Across many upstream version bumps `units.json` is *byte-identical* even though the mod genuinely changed things, so the modal often reported **"No tracked changes"** when real changes existed.

Verified examples (Exiles):
- `0.7.4.6` and `0.7.5` have identical `units.json`, yet the mod changed transport fire-while-loaded, ammo `damage_target`, build effects, and icons.
- `0.7.4.2 → 0.7.4.3` really changed `collision_check: "Enemies" → "target"` and a unit icon — both invisible before.

The raw changes live in the `assets/pa/**` source files (ammo/tool JSON, icons) that the web app **already downloads and caches** — we just weren't comparing them.

## Change (web-only — no CLI / extraction / workflow changes)

- **`staticFactionCache`** — `getAllStaticAssets(cacheKey)`: lists a version's cached raw files by key prefix.
- **`factionLoader`** — `loadFactionAssets(...)`: returns a version's raw file map; `null` in modes without cached assets (plain dev / local) so callers degrade gracefully.
- **`assetDiff`** (new) — diffs two raw file trees:
  - JSON files field-by-field with **verbatim PA field names** (e.g. `collision_check: "Enemies" → "target"`, `damage: 180 → 150 (-17%)`).
  - Binaries byte-compared (`Icon changed`).
  - Changes grouped by owning unit, **deduped** against the resolved diff, per-file capped.
  - Numeric arrays diff positionally (index-wise); string arrays use set difference.
  - A single malformed file degrades to a file-level note instead of sinking the whole comparison.
- **`VersionDiffModal`** — keeps the high-signal unit-stat sections on top, adds a muted **"Other changes"** section below, and replaces "No tracked changes" with an honest fallback — including **"Version-number bump only"** when nothing differs on either side.

## Testing

- New `assetDiff` unit suite (14 tests) + 3 new modal tests (raw section, version-bump fallback). **Full suite 916/916**, lint + typecheck clean.
- Ran `diffAssets` over **all** consecutive Exiles version pairs from git history — every pair produces changes, none crash.
- Verified live in `dev-live` against real production data:
  - `v0.7.4.6 → v0.7.5`: "Other changes (11)" incl. Heron transport gaining fire-while-loaded (previously invisible).
  - `v0.7.4.5 → v0.7.4.6`: "Other changes (3)" — this pair originally crashed the diff (array↔non-array field), now fixed and rendering cleanly.

## Note for reviewers

Effect-file (`.pfx`) rewiring is genuinely noisy and makes up much of some diffs. It's real, and the goal was to "call out anything", so it's kept (with per-file capping). Down-weighting/collapsing pure cosmetic changes would be an easy follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)