### PR TITLE
feat(web): add Sentry error monitoring and Cloudflare Web Analytics

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,9 +44,42 @@ jobs:
         working-directory: web
         run: npm run generate-sitemap
 
+      # Monitoring is configured entirely through these variables. Any that are
+      # unset simply disable their feature: no DSN means Sentry never
+      # initialises, no beacon token means the analytics script is not injected,
+      # and no Sentry auth token means sourcemaps are neither built nor
+      # uploaded. That keeps forks and PR builds from reporting into this
+      # project.
+      #
+      # VITE_SENTRY_DSN and VITE_CF_BEACON_TOKEN are public values (they ship in
+      # the client bundle); they are stored as secrets only so forks don't
+      # inherit them. SENTRY_AUTH_TOKEN is a real secret and is build-time only.
       - name: Build
         working-directory: web
+        env:
+          VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          VITE_SENTRY_ENVIRONMENT: production
+          VITE_CF_BEACON_TOKEN: ${{ secrets.CF_BEACON_TOKEN }}
+          VITE_APP_VERSION: ${{ github.sha }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         run: npm run build
+
+      # Sourcemaps are uploaded to Sentry during the build and then deleted from
+      # dist. A failed upload leaves them behind, and Pages would serve them —
+      # publishing our unminified source. Strip them here rather than failing:
+      # a Sentry outage should cost readable stack traces, not the deploy.
+      - name: Strip sourcemaps from build output
+        working-directory: web
+        run: |
+          set -euo pipefail
+          if find dist -name '*.map' -print -quit | grep -q .; then
+            echo "::warning::Sourcemaps left in dist (upload likely failed). Removing before deploy."
+            find dist -name '*.map' -print -delete
+          else
+            echo "No sourcemaps in dist."
+          fi
 
       # Download faction data from GitHub Releases and include in dist
       # This serves faction zips from the same origin, avoiding CORS issues

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,6 +64,9 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          # Required for EU-region Sentry orgs (https://de.sentry.io).
+          # Leave unset for US orgs; the plugin defaults to https://sentry.io.
+          SENTRY_URL: ${{ secrets.SENTRY_URL }}
         run: npm run build
 
       # Sourcemaps are uploaded to Sentry during the build and then deleted from

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,10 @@ jobs:
         env:
           VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           VITE_SENTRY_ENVIRONMENT: production
+          # Optional dial: set the repository variable to turn tracing down
+          # (or to 0) during a quota crunch without a code change. Unset falls
+          # back to the 0.1 default in monitoring.ts.
+          VITE_SENTRY_TRACES_SAMPLE_RATE: ${{ vars.SENTRY_TRACES_SAMPLE_RATE }}
           VITE_CF_BEACON_TOKEN: ${{ secrets.CF_BEACON_TOKEN }}
           VITE_APP_VERSION: ${{ github.sha }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,6 +278,33 @@ TypeScript types in `web/src/types/faction.ts` manually defined from schemas:
 - **Future Requirement**: If server-side faction sharing is implemented, add DOMPurify sanitization before storing/displaying shared content
 - **Best Practice**: Continue avoiding `dangerouslySetInnerHTML` for user-provided content
 
+### Monitoring (Sentry + Cloudflare Web Analytics)
+
+Both are free-tier and **inert unless configured** — no DSN means Sentry never initialises,
+no beacon token means the analytics script isn't injected. Dev, tests and CI send nothing.
+
+**Files**:
+- `web/src/lib/monitoring.ts` - Sentry init, event filtering, `reportError()` helper
+- `web/vite.config.ts` - `cloudflareWebAnalytics()` beacon injection + `sentryVitePlugin` sourcemap upload
+- `web/src/main.tsx` - `initMonitoring()` before render; React 19 root error hooks
+- `web/src/App.tsx` - `Sentry.wrapReactRouterRouting(Routes)` for parameterised route names
+- `web/src/components/ErrorBoundary.tsx` - reports caught errors with component stack
+- `web/.env.example` - all variables documented
+
+**Setup steps and free-tier rationale**: see the Monitoring section in [README.md](README.md).
+
+**Gotchas when touching this code**:
+- Use the non-deprecated `reactRouterBrowserTracingIntegration` / `wrapReactRouterRouting`
+  (Sentry v10 deprecated the `*V7*`-suffixed names).
+- Don't register `onCaughtError` on the React root — `ErrorBoundary` already reports those,
+  and both would double-count against the 5k/month quota.
+- Keep chunk-load sampling in `filterEvent()`. Without it, one stale-deploy incident
+  (see `web/public/_headers`) floods the quota.
+- Sentry's beforeSend logic is pure and unit-tested in `web/src/lib/__tests__/monitoring.test.ts` —
+  extend those tests when changing filters.
+- Adding new tracked routes? They're derived from the `<Route>` tree automatically; no manual
+  pageview calls needed.
+
 ### Faction Data Deployment
 
 **GitHub Actions Workflow** (`.github/workflows/faction-data.yml`):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,6 +289,8 @@ no beacon token means the analytics script isn't injected. Dev, tests and CI sen
 - `web/src/main.tsx` - `initMonitoring()` before render; React 19 root error hooks
 - `web/src/App.tsx` - `Sentry.wrapReactRouterRouting(Routes)` for parameterised route names
 - `web/src/components/ErrorBoundary.tsx` - reports caught errors with component stack
+- `reportError(err, { perVisitor: true })` marks outage-shaped failures, which `filterEvent`
+  samples at 10% — use it whenever a failure hits every visitor at once rather than one user
 - `web/.env.example` - all variables documented
 
 **Instrumented catch sites**: most failures here are caught and degraded gracefully, so they

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,6 +291,19 @@ no beacon token means the analytics script isn't injected. Dev, tests and CI sen
 - `web/src/components/ErrorBoundary.tsx` - reports caught errors with component stack
 - `web/.env.example` - all variables documented
 
+**Instrumented catch sites**: most failures here are caught and degraded gracefully, so they
+never reach a global handler and Sentry cannot see them unless the catch block reports.
+`reportError()` is called at the sites where the visitor's experience is actually broken:
+- `factionLoader.ts` - manifest load failure (site shows no factions) and local-faction
+  load failure (IndexedDB unavailable, reported at `warning` level)
+- `modelLoader.ts` - `getFactionModelsIndex` when the manifest promised a bundle that could
+  not be read; `UnitModelSection` discards this error by design, so Sentry is the only place
+  it surfaces
+
+Deliberately *not* reported: `zipHandler.ts` parse failures (user-uploaded files, already
+shown in the UI), the dev-only runtime discovery probe, and offline manifest fetches that
+fall back to cache successfully.
+
 **Setup steps and free-tier rationale**: see the Monitoring section in [README.md](README.md).
 
 **Gotchas when touching this code**:

--- a/README.md
+++ b/README.md
@@ -245,10 +245,16 @@ personal data.
 
 1. Create a Sentry project of type **React**, then copy its DSN.
 2. Add the repository secrets:
-   - `SENTRY_DSN` — the project DSN
-   - `SENTRY_ORG` — your Sentry org slug
-   - `SENTRY_PROJECT` — the project slug
-   - `SENTRY_AUTH_TOKEN` — an org auth token with `project:releases` scope, for sourcemap upload
+   - `SENTRY_DSN` — the project DSN, from **Settings → Projects → [project] → Client Keys (DSN)**
+   - `SENTRY_ORG` — your org slug (visible in the dashboard URL)
+   - `SENTRY_PROJECT` — the project slug (also in the dashboard URL)
+   - `SENTRY_AUTH_TOKEN` — an **organization** auth token with `project:releases` scope,
+     from **Settings → Auth Tokens**. Used for sourcemap upload.
+
+All three of `SENTRY_ORG`, `SENTRY_PROJECT` and `SENTRY_AUTH_TOKEN` are required for
+sourcemap upload — the Vite plugin checks for the org itself, so it is needed even though
+an organization auth token already embeds it. Setting some but not all makes the build warn
+and skip the upload rather than fail.
 
 `SENTRY_DSN` and `CF_BEACON_TOKEN` are public values that ship in the client bundle; they
 are stored as secrets only so forks don't report into this project. `SENTRY_AUTH_TOKEN` is

--- a/README.md
+++ b/README.md
@@ -214,6 +214,68 @@ npm run preview  # Preview production build
 npm run lint  # Run ESLint
 ```
 
+## Monitoring
+
+The deployed site reports errors to [Sentry](https://sentry.io) and traffic to
+[Cloudflare Web Analytics](https://www.cloudflare.com/web-analytics/). Both run on free
+tiers, and both are **off unless configured** — local dev, CI builds and forks send
+nothing.
+
+Configuration is entirely through environment variables (see [`web/.env.example`](web/.env.example));
+production values live in GitHub Actions secrets and are injected by
+[`.github/workflows/deploy.yml`](.github/workflows/deploy.yml).
+
+### One-time setup
+
+**Cloudflare Web Analytics** (page views, referrers, countries, devices):
+
+1. Cloudflare dashboard → **Analytics & Logs → Web Analytics → Add a site** → `pa-pedia.com`.
+2. Copy the 32-character site token from **Manage site**.
+3. Add it as the repository secret `CF_BEACON_TOKEN`.
+
+The beacon is injected into `index.html` at build time with `spa: true`, so React Router
+navigations are counted, not just the first page load. It is cookieless and stores no
+personal data.
+
+> Cloudflare Pages also offers a one-click Web Analytics toggle in the dashboard. Don't
+> enable both — you'll double-count every view. The build-time injection is used here
+> because it pins the SPA setting and survives a move off Pages.
+
+**Sentry** (JavaScript errors with stack traces):
+
+1. Create a Sentry project of type **React**, then copy its DSN.
+2. Add the repository secrets:
+   - `SENTRY_DSN` — the project DSN
+   - `SENTRY_ORG` — your Sentry org slug
+   - `SENTRY_PROJECT` — the project slug
+   - `SENTRY_AUTH_TOKEN` — an org auth token with `project:releases` scope, for sourcemap upload
+
+`SENTRY_DSN` and `CF_BEACON_TOKEN` are public values that ship in the client bundle; they
+are stored as secrets only so forks don't report into this project. `SENTRY_AUTH_TOKEN` is
+a real secret and is used at build time only.
+
+### Free-tier guardrails
+
+The Sentry free tier allows 5,000 errors/month, so the setup in
+[`web/src/lib/monitoring.ts`](web/src/lib/monitoring.ts) deliberately limits what is sent:
+
+- **Chunk-load errors are sampled at 5%** and collapsed into a single issue. A deploy that
+  strands users on a deleted bundle (see the comments in `web/public/_headers`) can throw
+  thousands of these — enough to burn the monthly quota in an afternoon. Sampling keeps the
+  signal without the flood.
+- **Browser-extension and `ResizeObserver` noise is dropped** — never actionable.
+- **Tracing is sampled at 10%** (`VITE_SENTRY_TRACES_SAMPLE_RATE`), since spans share the
+  free-tier quota with errors.
+- **Session Replay is not enabled.** The free tier includes 50 replays/month and the
+  integration roughly doubles the SDK's bundle cost. Add `Sentry.replayIntegration()` in
+  `monitoring.ts` if that trade changes.
+- **`sendDefaultPii` is off**, so visitor IPs and headers are never attached.
+
+Sourcemaps are generated only when `SENTRY_AUTH_TOKEN` is set, uploaded to Sentry, then
+deleted from `dist/` so they are never served publicly. If the upload fails the build still
+succeeds — that release just gets minified stack traces — and the deploy workflow strips any
+maps left behind.
+
 ## PA Installation Paths
 
 **Windows**:

--- a/README.md
+++ b/README.md
@@ -256,6 +256,10 @@ sourcemap upload — the Vite plugin checks for the org itself, so it is needed 
 an organization auth token already embeds it. Setting some but not all makes the build warn
 and skip the upload rather than fail.
 
+**EU-region orgs**: if your DSN contains `.de.` (e.g. `o123.ingest.de.sentry.io`), also add
+`SENTRY_URL=https://de.sentry.io`. The bundler plugin hardcodes the US endpoint when this is
+unset, so every upload fails against an EU org.
+
 `SENTRY_DSN` and `CF_BEACON_TOKEN` are public values that ship in the client bundle; they
 are stored as secrets only so forks don't report into this project. `SENTRY_AUTH_TOKEN` is
 a real secret and is used at build time only.

--- a/web/.env.example
+++ b/web/.env.example
@@ -35,6 +35,11 @@ SENTRY_AUTH_TOKEN=
 SENTRY_ORG=
 SENTRY_PROJECT=
 
+# Sentry region endpoint. Required for EU orgs — if your DSN contains
+# `.de.` (e.g. o123.ingest.de.sentry.io), set this to https://de.sentry.io,
+# otherwise uploads hit the US endpoint and fail. Leave empty for US orgs.
+SENTRY_URL=
+
 # --- Local data sources -----------------------------------------------------
 
 # Load faction data from production (https://pa-pedia.com) instead of local

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,47 @@
+# Web app environment variables.
+#
+# Copy to `web/.env.local` for local overrides. Production values are set as
+# GitHub Actions secrets and injected by .github/workflows/deploy.yml.
+
+# --- Monitoring -------------------------------------------------------------
+
+# Sentry DSN. When empty (the default for dev and CI), Sentry never initialises
+# and no events are sent. Not a secret — it ships in the client bundle.
+VITE_SENTRY_DSN=
+
+# Environment name shown in Sentry. Defaults to the Vite mode.
+VITE_SENTRY_ENVIRONMENT=
+
+# Fraction of navigations sampled for performance tracing (0 to 1).
+# Defaults to 0.1. Tracing shares the free-tier quota with errors — raising this
+# is the fastest way to exhaust it.
+VITE_SENTRY_TRACES_SAMPLE_RATE=0.1
+
+# Release identifier, used to tie stack traces to uploaded sourcemaps.
+# CI sets this to the commit SHA.
+VITE_APP_VERSION=
+
+# Cloudflare Web Analytics site token (32 hex chars), from
+# Cloudflare dashboard > Analytics & Logs > Web Analytics > your site > Manage
+# site. Only injected in production builds. Not a secret — it is public in the
+# deployed HTML by design.
+VITE_CF_BEACON_TOKEN=
+
+# Sourcemap upload to Sentry. Build-time only (never exposed to the browser).
+# All three must be set for upload to run; otherwise the build skips it and
+# emits no sourcemaps.
+SENTRY_AUTH_TOKEN=
+SENTRY_ORG=
+SENTRY_PROJECT=
+
+# --- Local data sources -----------------------------------------------------
+
+# Load faction data from production (https://pa-pedia.com) instead of local
+# files. Useful for testing against real data without a PA install.
+VITE_USE_LIVE_DATA=false
+
+# Override the local faction data directory (default: ../factions).
+VITE_FACTIONS_DIR=
+
+# Override the local 3D model directory (default: ../faction-models).
+VITE_FACTION_MODELS_DIR=

--- a/web/.env.example
+++ b/web/.env.example
@@ -28,8 +28,9 @@ VITE_APP_VERSION=
 VITE_CF_BEACON_TOKEN=
 
 # Sourcemap upload to Sentry. Build-time only (never exposed to the browser).
-# All three must be set for upload to run; otherwise the build skips it and
-# emits no sourcemaps.
+# All three are required — the Vite plugin needs SENTRY_ORG explicitly even
+# when using an organization auth token that already embeds the org. Set some
+# but not all and the build warns, then emits no sourcemaps.
 SENTRY_AUTH_TOKEN=
 SENTRY_ORG=
 SENTRY_PROJECT=

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,6 +11,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@sentry/react": "^10.68.0",
         "@types/dompurify": "^3.2.0",
         "@zip.js/zip.js": "^2.8.31",
         "clsx": "^2.1.1",
@@ -29,6 +30,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.61.1",
+        "@sentry/vite-plugin": "^5.4.0",
         "@tailwindcss/vite": "^4.3.3",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -1614,9 +1616,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1634,9 +1633,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1654,9 +1650,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1674,9 +1667,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1694,9 +1684,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1714,9 +1701,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1802,6 +1786,330 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.68.0.tgz",
+      "integrity": "sha512-8xVgk7oG2lajXnbXF6a7H1xMZ/U6icqSldHGzQu1+bajfrK8Gan9ULG/Xsj1VM1LlNeK6/7znDJ3u1jgvIwznw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.68.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0",
+        "@sentry/feedback": "10.68.0",
+        "@sentry/replay": "10.68.0",
+        "@sentry/replay-canvas": "10.68.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.68.0.tgz",
+      "integrity": "sha512-be8VtdjCngKc77cstJeV+gO15iH+blyXpBDk8yOehmtX4BkFO33mfTMNCWVR2LA0oOxjIHWRAhf77fIUEhzxPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/bundler-plugins": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugins/-/bundler-plugins-10.68.0.tgz",
+      "integrity": "sha512-XWv7asJuTTUSlacROvqcIFKuNxAf3PYL/mdjMBhBwp3rJ4vMkA73jqNPjqCTm726cHs/Y4yadbbFA/OZLPWzeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.18.5",
+        "@sentry/cli": "^2.58.6",
+        "@sentry/core": "10.68.0",
+        "dotenv": "^17.4.2",
+        "find-up": "^5.0.0",
+        "glob": "^13.0.6",
+        "magic-string": "~0.30.8"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "rollup": ">=3.2.0",
+        "webpack": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.6.tgz",
+      "integrity": "sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "FSL-1.1-MIT",
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.58.6",
+        "@sentry/cli-linux-arm": "2.58.6",
+        "@sentry/cli-linux-arm64": "2.58.6",
+        "@sentry/cli-linux-i686": "2.58.6",
+        "@sentry/cli-linux-x64": "2.58.6",
+        "@sentry/cli-win32-arm64": "2.58.6",
+        "@sentry/cli-win32-i686": "2.58.6",
+        "@sentry/cli-win32-x64": "2.58.6"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.6.tgz",
+      "integrity": "sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==",
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.6.tgz",
+      "integrity": "sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.6.tgz",
+      "integrity": "sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.6.tgz",
+      "integrity": "sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.6.tgz",
+      "integrity": "sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.6.tgz",
+      "integrity": "sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.6.tgz",
+      "integrity": "sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.6.tgz",
+      "integrity": "sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.68.0.tgz",
+      "integrity": "sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/feedback": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.68.0.tgz",
+      "integrity": "sha512-XbdcXiBnpC3vgw46eHOPeD/ZQ+XzluP75ubdUcaPDW02hCh2nsdXiwjZ2DBImbpvIpTbJgjHf/sIlHWvcZJ2Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.68.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.68.0.tgz",
+      "integrity": "sha512-rIq4QR4ScMHHx9JJZv7Jgw31bMdUVJMx+ykHIJb7htjY6mj78sjKs+KpCsMDnvJxDhSmvftGM1KfKD4BggL7OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.68.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.68.0.tgz",
+      "integrity": "sha512-ZoG2n16vbkx4GWSCnLIqUUN9xlUmccQFbQ2US2rhruQeHTUnHl/ukr8NHOQXZaEbwKyMkX9bEMwfmZHJm+wSTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.68.0",
+        "@sentry/core": "10.68.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.68.0.tgz",
+      "integrity": "sha512-HusYcr+He+ohnUDHunYrc5St6vdDnBXpUAndnT5ReyUMVSCiWKfY3paXowU/0787HwYfxdcpZgwC5u79+XbEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.68.0",
+        "@sentry/replay": "10.68.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/vite-plugin": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-5.4.0.tgz",
+      "integrity": "sha512-fFJgCxs5hDyAm9BbZJ+LbA+LK2tjX5OoD0v0ARU4StR6KQmGUduoPs69yJ9AfqZ0om3Rlp5JDliiwFcNkasORA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/bundler-plugins": "^10.64.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -1943,9 +2251,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1963,9 +2268,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1983,9 +2285,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2003,9 +2302,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2923,6 +3219,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -3416,6 +3725,19 @@
         "@types/trusted-types": "^2.0.7"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.393",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
@@ -3899,6 +4221,24 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -4050,6 +4390,20 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/idb": {
       "version": "8.0.3",
@@ -4917,6 +5271,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -4958,6 +5322,52 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.51",
@@ -5139,6 +5549,33 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -5313,6 +5750,16 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -5339,6 +5786,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/web/package.json
+++ b/web/package.json
@@ -22,6 +22,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@sentry/react": "^10.68.0",
     "@types/dompurify": "^3.2.0",
     "@zip.js/zip.js": "^2.8.31",
     "clsx": "^2.1.1",
@@ -40,6 +41,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.61.1",
+    "@sentry/vite-plugin": "^5.4.0",
     "@tailwindcss/vite": "^4.3.3",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import * as Sentry from '@sentry/react'
 import { FactionProvider } from '@/contexts/FactionContext'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
 import { Header } from '@/components/Header'
@@ -9,6 +10,10 @@ import { CliDownload } from '@/components/CliDownload'
 import { Home } from '@/pages/Home'
 import { FactionDetail } from '@/pages/FactionDetail'
 import { UnitDetail } from '@/pages/UnitDetail'
+
+// Gives Sentry the parameterised route (/faction/:id) rather than the raw URL,
+// so navigations group into one transaction per page instead of one per unit.
+const SentryRoutes = Sentry.wrapReactRouterRouting(Routes)
 
 function App() {
   const [showUpload, setShowUpload] = useState(false)
@@ -24,12 +29,12 @@ function App() {
               onUploadClick={() => setShowUpload(true)}
               onDownloadClick={() => setShowCliDownload(true)}
             />
-            <Routes>
+            <SentryRoutes>
               <Route path="/" element={<Home />} />
               <Route path="/faction" element={<FactionDetail />} />
               <Route path="/faction/:id" element={<FactionDetail />} />
               <Route path="/faction/:factionId/unit/:unitId" element={<UnitDetail />} />
-            </Routes>
+            </SentryRoutes>
 
             {/* Modals */}
             {showUpload && (

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -23,7 +23,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     console.error('Error caught by boundary:', error, errorInfo)
-    reportError(error, { componentStack: errorInfo.componentStack })
+    reportError(error, { context: { componentStack: errorInfo.componentStack } })
   }
 
   render() {

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { reportError } from '@/lib/monitoring'
 
 interface Props {
   children: React.ReactNode
@@ -22,6 +23,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     console.error('Error caught by boundary:', error, errorInfo)
+    reportError(error, { componentStack: errorInfo.componentStack })
   }
 
   render() {

--- a/web/src/lib/__tests__/monitoring.init.test.ts
+++ b/web/src/lib/__tests__/monitoring.init.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mocked wholesale: these tests assert what monitoring.ts asks the SDK to do,
+// not what the SDK then does. Kept in its own file so the filterEvent tests
+// still exercise the real types.
+vi.mock('@sentry/react', () => ({
+  init: vi.fn(),
+  captureException: vi.fn(),
+  reactRouterBrowserTracingIntegration: vi.fn(() => ({ name: 'router' })),
+}))
+
+import * as Sentry from '@sentry/react'
+import { initMonitoring, isMonitoringEnabled, reportError } from '../monitoring'
+
+describe('initMonitoring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // The load-bearing safety property: without a DSN nothing is ever sent, which
+  // is what keeps dev, CI and forks off the 5k/month quota.
+  it('does not initialise Sentry when no DSN is configured', () => {
+    expect(import.meta.env.VITE_SENTRY_DSN).toBeFalsy()
+
+    initMonitoring()
+
+    expect(Sentry.init).not.toHaveBeenCalled()
+    expect(isMonitoringEnabled()).toBe(false)
+  })
+})
+
+describe('reportError', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('defaults to error level with no extra or tags', () => {
+    const error = new Error('boom')
+    reportError(error)
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(error, { level: 'error' })
+  })
+
+  it('passes context through as extra', () => {
+    const error = new Error('boom')
+    reportError(error, { context: { stage: 'discoverFactions:manifest' } })
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(error, {
+      level: 'error',
+      extra: { stage: 'discoverFactions:manifest' },
+    })
+  })
+
+  it('honours an explicit severity level', () => {
+    const error = new Error('idb unavailable')
+    reportError(error, { level: 'warning' })
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(error, { level: 'warning' })
+  })
+
+  // The tag is what filterEvent samples on; without it an outage would be
+  // reported once per visitor at full rate.
+  it('tags per-visitor failures so filterEvent can sample them', () => {
+    const error = new Error('No manifest available')
+    reportError(error, { context: { stage: 'x' }, perVisitor: true })
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(error, {
+      level: 'error',
+      extra: { stage: 'x' },
+      tags: { volume: 'per-visitor' },
+    })
+  })
+})

--- a/web/src/lib/__tests__/monitoring.test.ts
+++ b/web/src/lib/__tests__/monitoring.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest'
+import type { ErrorEvent, EventHint } from '@sentry/react'
+import {
+  isChunkLoadError,
+  eventMessage,
+  filterEvent,
+  parseSampleRate,
+} from '../monitoring'
+
+/** Minimal Sentry error event carrying a single exception value. */
+function errorEvent(type: string, value: string): ErrorEvent {
+  return {
+    type: undefined,
+    exception: { values: [{ type, value }] },
+  } as ErrorEvent
+}
+
+describe('isChunkLoadError', () => {
+  // These are the real messages browsers emit when a stale index.html points at
+  // a bundle the latest deploy deleted.
+  it.each([
+    'Failed to fetch dynamically imported module: https://pa-pedia.com/assets/UnitDetail-a1b2c3.js',
+    'error loading dynamically imported module',
+    'Importing a module script failed.',
+    'ChunkLoadError: Loading chunk 42 failed.',
+    'Unable to preload CSS for /assets/index-9f8e7d.css',
+  ])('detects %s', message => {
+    expect(isChunkLoadError(message)).toBe(true)
+  })
+
+  it('does not match ordinary application errors', () => {
+    expect(isChunkLoadError('Cannot read properties of undefined')).toBe(false)
+    expect(isChunkLoadError('QuotaExceededError: IndexedDB is full')).toBe(false)
+    expect(isChunkLoadError('Failed to fetch')).toBe(false)
+  })
+})
+
+describe('eventMessage', () => {
+  it('reads the exception type and value', () => {
+    const message = eventMessage(errorEvent('TypeError', 'x is not a function'))
+    expect(message).toContain('TypeError')
+    expect(message).toContain('x is not a function')
+  })
+
+  it('falls back to the original exception from the hint', () => {
+    const event = { type: undefined } as ErrorEvent
+    const hint = { originalException: new Error('ChunkLoadError') } as EventHint
+    expect(eventMessage(event, hint)).toContain('ChunkLoadError')
+  })
+
+  it('handles events with no exception data', () => {
+    expect(eventMessage({ type: undefined } as ErrorEvent)).toBe('')
+  })
+})
+
+describe('parseSampleRate', () => {
+  it('parses a valid rate', () => {
+    expect(parseSampleRate('0.25', 0.1)).toBe(0.25)
+    expect(parseSampleRate('0', 0.1)).toBe(0)
+    expect(parseSampleRate('1', 0.1)).toBe(1)
+  })
+
+  it('falls back when the variable is unset or blank', () => {
+    // Vite yields '' for keys present but empty in .env; Number('') is 0, which
+    // would silently disable tracing instead of using the default.
+    expect(parseSampleRate('', 0.1)).toBe(0.1)
+    expect(parseSampleRate('   ', 0.1)).toBe(0.1)
+    expect(parseSampleRate(undefined, 0.1)).toBe(0.1)
+  })
+
+  it('falls back on non-numeric or out-of-range values', () => {
+    expect(parseSampleRate('abc', 0.1)).toBe(0.1)
+    expect(parseSampleRate('-1', 0.1)).toBe(0.1)
+    expect(parseSampleRate('1.5', 0.1)).toBe(0.1)
+    expect(parseSampleRate('Infinity', 0.1)).toBe(0.1)
+  })
+})
+
+describe('filterEvent', () => {
+  it('passes ordinary errors through untouched', () => {
+    const event = errorEvent('TypeError', 'units is not iterable')
+    const result = filterEvent(event, undefined, () => 0.99)
+
+    expect(result).toBe(event)
+    expect(result?.fingerprint).toBeUndefined()
+  })
+
+  it('drops chunk-load errors outside the sample rate', () => {
+    const event = errorEvent('TypeError', 'Failed to fetch dynamically imported module')
+    // 0.5 is well above the 0.05 sample rate.
+    expect(filterEvent(event, undefined, () => 0.5)).toBeNull()
+  })
+
+  it('keeps sampled chunk-load errors, grouped into one issue', () => {
+    const event = errorEvent('TypeError', 'Failed to fetch dynamically imported module')
+    const result = filterEvent(event, undefined, () => 0.01)
+
+    expect(result).not.toBeNull()
+    // Every hashed-filename variant must collapse to a single Sentry issue.
+    expect(result?.fingerprint).toEqual(['chunk-load-error'])
+    expect(result?.tags?.error_class).toBe('chunk-load')
+    expect(result?.level).toBe('warning')
+  })
+
+  it('samples chunk-load errors at roughly the configured rate', () => {
+    let kept = 0
+    for (let i = 0; i < 1000; i++) {
+      const event = errorEvent('TypeError', 'Failed to fetch dynamically imported module')
+      // Deterministic sweep across [0, 1) instead of real randomness.
+      if (filterEvent(event, undefined, () => i / 1000)) kept++
+    }
+    expect(kept).toBe(50) // 5% of 1000
+  })
+
+  it('preserves existing tags when tagging a chunk-load error', () => {
+    const event = errorEvent('TypeError', 'ChunkLoadError')
+    event.tags = { faction: 'MLA' }
+    const result = filterEvent(event, undefined, () => 0)
+
+    expect(result?.tags).toEqual({ faction: 'MLA', error_class: 'chunk-load' })
+  })
+})

--- a/web/src/lib/__tests__/monitoring.test.ts
+++ b/web/src/lib/__tests__/monitoring.test.ts
@@ -51,6 +51,22 @@ describe('eventMessage', () => {
   it('handles events with no exception data', () => {
     expect(eventMessage({ type: undefined } as ErrorEvent)).toBe('')
   })
+
+  it('reads non-Error throwables such as DOMException', () => {
+    // DOMException does not inherit from Error in browsers, and IndexedDB and
+    // fetch both throw it. An instanceof check would miss the message.
+    const event = { type: undefined } as ErrorEvent
+    const hint = {
+      originalException: { name: 'QuotaExceededError', message: 'ChunkLoadError' },
+    } as unknown as EventHint
+    expect(eventMessage(event, hint)).toContain('ChunkLoadError')
+  })
+
+  it('ignores a hint whose message is not a string', () => {
+    const event = { type: undefined } as ErrorEvent
+    const hint = { originalException: { message: 42 } } as unknown as EventHint
+    expect(eventMessage(event, hint)).toBe('')
+  })
 })
 
 describe('parseSampleRate', () => {
@@ -110,6 +126,35 @@ describe('filterEvent', () => {
       if (filterEvent(event, undefined, () => i / 1000)) kept++
     }
     expect(kept).toBe(50) // 5% of 1000
+  })
+
+  it('drops per-visitor events outside their sample rate', () => {
+    const event = errorEvent('Error', 'No manifest available')
+    event.tags = { volume: 'per-visitor' }
+    // 0.5 is above the 0.1 per-visitor rate.
+    expect(filterEvent(event, undefined, () => 0.5)).toBeNull()
+  })
+
+  it('keeps sampled per-visitor events', () => {
+    const event = errorEvent('Error', 'No manifest available')
+    event.tags = { volume: 'per-visitor' }
+    expect(filterEvent(event, undefined, () => 0.05)).toBe(event)
+  })
+
+  it('samples per-visitor events at roughly the configured rate', () => {
+    let kept = 0
+    for (let i = 0; i < 1000; i++) {
+      const event = errorEvent('Error', 'No manifest available')
+      event.tags = { volume: 'per-visitor' }
+      if (filterEvent(event, undefined, () => i / 1000)) kept++
+    }
+    expect(kept).toBe(100) // 10% of 1000
+  })
+
+  it('does not sample untagged events', () => {
+    const event = errorEvent('Error', 'No manifest available')
+    // Same message, no per-visitor tag: must always be kept.
+    expect(filterEvent(event, undefined, () => 0.99)).toBe(event)
   })
 
   it('preserves existing tags when tagging a chunk-load error', () => {

--- a/web/src/lib/monitoring.ts
+++ b/web/src/lib/monitoring.ts
@@ -20,8 +20,17 @@ import type { ErrorEvent, EventHint, SeverityLevel } from '@sentry/react'
  * bundle cost. Add `Sentry.replayIntegration()` here if that trade changes.
  */
 
-/** Fraction of chunk-load errors that get reported. See shouldSampleChunkLoadError. */
+/** Fraction of chunk-load errors that get reported. See isChunkLoadError. */
 const CHUNK_LOAD_SAMPLE_RATE = 0.05
+
+/**
+ * Tag marking failures that hit every affected visitor exactly once — an
+ * outage shape, not a per-user bug. A broken manifest or an unreadable model
+ * bundle produces one event per visitor for as long as it lasts, which is the
+ * same quota risk as a chunk-load storm and needs the same treatment.
+ */
+const PER_VISITOR_TAG = 'per-visitor'
+const PER_VISITOR_SAMPLE_RATE = 0.1
 
 /**
  * Errors that are never actionable for us: browser extensions injecting into
@@ -67,8 +76,11 @@ export function eventMessage(event: ErrorEvent, hint?: EventHint): string {
   const fromException = values
     .map(v => `${v.type ?? ''}: ${v.value ?? ''}`)
     .join(' ')
-  const fromHint =
-    hint?.originalException instanceof Error ? hint.originalException.message : ''
+  // Structural check rather than `instanceof Error`: DOMException (thrown by
+  // IndexedDB and fetch) does not inherit from Error in browsers, and errors
+  // crossing a realm boundary fail instanceof too.
+  const original = hint?.originalException as { message?: unknown } | undefined
+  const fromHint = typeof original?.message === 'string' ? original.message : ''
   return [event.message ?? '', fromException, fromHint].join(' ').trim()
 }
 
@@ -92,6 +104,15 @@ export function filterEvent(
     event.fingerprint = ['chunk-load-error']
     event.tags = { ...event.tags, error_class: 'chunk-load' }
     event.level = 'warning'
+    return event
+  }
+
+  // Outage-shaped failures reported via reportError({ perVisitor: true }).
+  // Sampled for the same reason as chunk-load errors: the event count scales
+  // with how many people visit during the outage, not with how many distinct
+  // bugs exist. 10% still surfaces the issue within a handful of visitors.
+  if (event.tags?.volume === PER_VISITOR_TAG && random() >= PER_VISITOR_SAMPLE_RATE) {
+    return null
   }
 
   return event
@@ -168,13 +189,23 @@ export function initMonitoring(): void {
  * Safe to call when monitoring is disabled: Sentry's capture functions are
  * no-ops until init runs.
  */
-export function reportError(
-  error: unknown,
-  context?: Record<string, unknown>,
-  level: SeverityLevel = 'error',
-): void {
+export interface ReportOptions {
+  /** Extra detail attached to the event. Never put visitor data here. */
+  context?: Record<string, unknown>
+  level?: SeverityLevel
+  /**
+   * Set for failures that hit every affected visitor once, rather than
+   * indicating a bug specific to one user. Such events are sampled — see
+   * PER_VISITOR_SAMPLE_RATE — so an outage cannot drain the monthly quota.
+   */
+  perVisitor?: boolean
+}
+export function reportError(error: unknown, options: ReportOptions = {}): void {
+  const { context, level = 'error', perVisitor = false } = options
+
   Sentry.captureException(error, {
     level,
     ...(context ? { extra: context } : {}),
+    ...(perVisitor ? { tags: { volume: PER_VISITOR_TAG } } : {}),
   })
 }

--- a/web/src/lib/monitoring.ts
+++ b/web/src/lib/monitoring.ts
@@ -1,0 +1,171 @@
+import React from 'react'
+import * as Sentry from '@sentry/react'
+import {
+  useLocation,
+  useNavigationType,
+  createRoutesFromChildren,
+  matchRoutes,
+} from 'react-router-dom'
+import type { ErrorEvent, EventHint } from '@sentry/react'
+
+/**
+ * Sentry error monitoring.
+ *
+ * Only initialises when VITE_SENTRY_DSN is set, so local dev and CI builds stay
+ * silent and never burn quota. The free Sentry tier allows 5k errors/month —
+ * every filter below exists to keep a single bad day from consuming it.
+ *
+ * Deliberately no Session Replay: the free tier includes 50 replays/month
+ * (gone after one bad deploy) and the integration roughly doubles the SDK's
+ * bundle cost. Add `Sentry.replayIntegration()` here if that trade changes.
+ */
+
+/** Fraction of chunk-load errors that get reported. See shouldSampleChunkLoadError. */
+const CHUNK_LOAD_SAMPLE_RATE = 0.05
+
+/**
+ * Errors that are never actionable for us: browser extensions injecting into
+ * the page, and the benign ResizeObserver notification that fires whenever a
+ * resize handler itself resizes something (our masonry/table layouts trigger it).
+ */
+const IGNORED_ERRORS = [
+  'ResizeObserver loop limit exceeded',
+  'ResizeObserver loop completed with undelivered notifications',
+  'Non-Error promise rejection captured with value: undefined',
+  // Safari/Firefox private mode blocks IndexedDB entirely; the app already
+  // degrades gracefully and there is nothing to fix on our side.
+  'A mutation operation was attempted on a database that did not allow mutations',
+]
+
+const DENIED_URLS = [
+  /^chrome-extension:\/\//i,
+  /^moz-extension:\/\//i,
+  /^safari-(web-)?extension:\/\//i,
+]
+
+/**
+ * Detects the "stale index.html points at a deleted bundle" failure — the exact
+ * outage documented in web/public/_headers and .github/workflows/deploy.yml.
+ *
+ * Every user still on the old chunk graph throws one of these, so a single bad
+ * deploy can produce thousands of events. We keep them (they are the earliest
+ * signal that a deploy stranded users) but sample them hard.
+ */
+export function isChunkLoadError(message: string): boolean {
+  return (
+    /Failed to fetch dynamically imported module/i.test(message) ||
+    /error loading dynamically imported module/i.test(message) ||
+    /Importing a module script failed/i.test(message) ||
+    /ChunkLoadError/i.test(message) ||
+    /Unable to preload CSS/i.test(message)
+  )
+}
+
+/** Extracts a searchable message from a Sentry event and its original error. */
+export function eventMessage(event: ErrorEvent, hint?: EventHint): string {
+  const values = event.exception?.values ?? []
+  const fromException = values
+    .map(v => `${v.type ?? ''}: ${v.value ?? ''}`)
+    .join(' ')
+  const fromHint =
+    hint?.originalException instanceof Error ? hint.originalException.message : ''
+  return [event.message ?? '', fromException, fromHint].join(' ').trim()
+}
+
+/**
+ * beforeSend hook: drops noise and rate-limits chunk-load storms.
+ *
+ * `random` is injected so the sampling decision is testable.
+ */
+export function filterEvent(
+  event: ErrorEvent,
+  hint?: EventHint,
+  random: () => number = Math.random,
+): ErrorEvent | null {
+  const message = eventMessage(event, hint)
+
+  if (isChunkLoadError(message)) {
+    if (random() >= CHUNK_LOAD_SAMPLE_RATE) return null
+
+    // Collapse every variant (each references a different hashed filename)
+    // into one issue instead of one issue per deploy per chunk.
+    event.fingerprint = ['chunk-load-error']
+    event.tags = { ...event.tags, error_class: 'chunk-load' }
+    event.level = 'warning'
+  }
+
+  return event
+}
+
+/** Whether monitoring is configured for this build. */
+export function isMonitoringEnabled(): boolean {
+  return Boolean(import.meta.env.VITE_SENTRY_DSN)
+}
+
+/**
+ * Parses a sample rate from an env var, falling back to the default.
+ *
+ * `.env` files yield empty strings for unset keys, and `Number('')` is 0 —
+ * which would silently disable tracing rather than use the default.
+ */
+export function parseSampleRate(raw: unknown, fallback: number): number {
+  if (typeof raw !== 'string' || raw.trim() === '') return fallback
+  const value = Number(raw)
+  if (!Number.isFinite(value) || value < 0 || value > 1) return fallback
+  return value
+}
+
+/**
+ * Initialise Sentry. Call once, before React renders, so errors thrown during
+ * the first paint are captured.
+ */
+export function initMonitoring(): void {
+  const dsn = import.meta.env.VITE_SENTRY_DSN
+  if (!dsn) return
+
+  const tracesSampleRate = parseSampleRate(
+    import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE,
+    0.1,
+  )
+
+  Sentry.init({
+    dsn,
+    environment: import.meta.env.VITE_SENTRY_ENVIRONMENT || import.meta.env.MODE,
+    release: import.meta.env.VITE_APP_VERSION || undefined,
+
+    integrations: [
+      Sentry.reactRouterBrowserTracingIntegration({
+        useEffect: React.useEffect,
+        useLocation,
+        useNavigationType,
+        createRoutesFromChildren,
+        matchRoutes,
+      }),
+    ],
+
+    // Performance tracing shares the free-tier quota with errors, so keep the
+    // sample rate low. Errors are always sent at 100% (minus the filters above).
+    tracesSampleRate,
+
+    // This is a public reference site with no accounts. Never attach IPs,
+    // cookies or headers that could identify a visitor.
+    sendDefaultPii: false,
+
+    ignoreErrors: IGNORED_ERRORS,
+    denyUrls: DENIED_URLS,
+    beforeSend: (event, hint) => filterEvent(event, hint),
+  })
+}
+
+/**
+ * Report a handled error with extra context.
+ *
+ * Used by ErrorBoundary; safe to call when monitoring is disabled (Sentry's
+ * capture functions are no-ops until init runs).
+ */
+export function reportError(
+  error: unknown,
+  context?: Record<string, unknown>,
+): void {
+  Sentry.captureException(error, context ? { extra: context } : undefined)
+}

--- a/web/src/lib/monitoring.ts
+++ b/web/src/lib/monitoring.ts
@@ -6,7 +6,7 @@ import {
   createRoutesFromChildren,
   matchRoutes,
 } from 'react-router-dom'
-import type { ErrorEvent, EventHint } from '@sentry/react'
+import type { ErrorEvent, EventHint, SeverityLevel } from '@sentry/react'
 
 /**
  * Sentry error monitoring.
@@ -160,12 +160,21 @@ export function initMonitoring(): void {
 /**
  * Report a handled error with extra context.
  *
- * Used by ErrorBoundary; safe to call when monitoring is disabled (Sentry's
- * capture functions are no-ops until init runs).
+ * Most of this app's interesting failures are caught and degraded gracefully
+ * (a missing manifest, an unreadable model bundle), so they never reach a
+ * global handler. Call this at those catch sites — otherwise the failure is
+ * invisible to us and only the user sees the degraded UI.
+ *
+ * Safe to call when monitoring is disabled: Sentry's capture functions are
+ * no-ops until init runs.
  */
 export function reportError(
   error: unknown,
   context?: Record<string, unknown>,
+  level: SeverityLevel = 'error',
 ): void {
-  Sentry.captureException(error, context ? { extra: context } : undefined)
+  Sentry.captureException(error, {
+    level,
+    ...(context ? { extra: context } : {}),
+  })
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -3,18 +3,31 @@ import { createRoot } from 'react-dom/client'
 import * as Sentry from '@sentry/react'
 import './index.css'
 import App from './App.tsx'
-import { initMonitoring } from '@/lib/monitoring'
+import { initMonitoring, isMonitoringEnabled } from '@/lib/monitoring'
 
 // Before render, so errors thrown during the first paint are captured.
 initMonitoring()
 
-createRoot(document.getElementById('root')!, {
-  // React 19 root error hooks. onCaughtError is deliberately omitted: errors
-  // our ErrorBoundary catches are reported there with component context, and
-  // registering both would double-count them against the Sentry quota.
-  onUncaughtError: Sentry.reactErrorHandler(),
-  onRecoverableError: Sentry.reactErrorHandler(),
-}).render(
+// React 19 root error hooks, registered ONLY when Sentry can receive the error.
+//
+// React's defaults route these to reportGlobalError, which logs to the console.
+// Sentry.reactErrorHandler() with no callback captures and returns without
+// logging, so registering it unconditionally would swallow errors entirely
+// wherever there is no DSN — dev, CI, forks — turning a stack trace into a
+// blank page with an empty console. Passing a logging callback is not an
+// alternative: it flips the SDK's `mechanism.handled` to true and mislabels
+// genuinely unhandled errors.
+//
+// onCaughtError stays unregistered in both cases: ErrorBoundary already reports
+// those with component context, and both would double-count against the quota.
+const rootOptions = isMonitoringEnabled()
+  ? {
+      onUncaughtError: Sentry.reactErrorHandler(),
+      onRecoverableError: Sentry.reactErrorHandler(),
+    }
+  : {}
+
+createRoot(document.getElementById('root')!, rootOptions).render(
   <StrictMode>
     <App />
   </StrictMode>,

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,9 +1,20 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import * as Sentry from '@sentry/react'
 import './index.css'
 import App from './App.tsx'
+import { initMonitoring } from '@/lib/monitoring'
 
-createRoot(document.getElementById('root')!).render(
+// Before render, so errors thrown during the first paint are captured.
+initMonitoring()
+
+createRoot(document.getElementById('root')!, {
+  // React 19 root error hooks. onCaughtError is deliberately omitted: errors
+  // our ErrorBoundary catches are reported there with component context, and
+  // registering both would double-count them against the Sentry quota.
+  onUncaughtError: Sentry.reactErrorHandler(),
+  onRecoverableError: Sentry.reactErrorHandler(),
+}).render(
   <StrictMode>
     <App />
   </StrictMode>,

--- a/web/src/services/factionLoader.ts
+++ b/web/src/services/factionLoader.ts
@@ -143,7 +143,14 @@ export async function discoverFactions(): Promise<FactionDiscoveryEntry[]> {
       // Worth reporting: manifestLoader only throws here when the network
       // failed AND there is no cache, so the visitor sees a site with no
       // factions at all. Offline visitors with a warm cache never reach this.
-      reportError(error, { stage: 'discoverFactions:manifest' })
+      //
+      // perVisitor: a missing or unreachable manifest breaks the site for
+      // everyone at once, producing one event per visitor for as long as it
+      // lasts. Sampled so an outage cannot drain the monthly quota.
+      reportError(error, {
+        context: { stage: 'discoverFactions:manifest' },
+        perVisitor: true,
+      })
     }
   }
 
@@ -157,7 +164,12 @@ export async function discoverFactions(): Promise<FactionDiscoveryEntry[]> {
     console.warn('Failed to load local factions:', error)
     // Usually IndexedDB being unavailable (private browsing, storage pressure).
     // Warning level: the rest of the site still works.
-    reportError(error, { stage: 'discoverFactions:local' }, 'warning')
+    // Not perVisitor: this depends on the individual browser's storage state,
+    // so the volume scales with affected users, not with an outage.
+    reportError(error, {
+      context: { stage: 'discoverFactions:local' },
+      level: 'warning',
+    })
   }
 
   return entries

--- a/web/src/services/factionLoader.ts
+++ b/web/src/services/factionLoader.ts
@@ -9,6 +9,7 @@
 
 import JSZip from 'jszip'
 import type { FactionMetadata, FactionIndex } from '@/types/faction'
+import { reportError } from '@/lib/monitoring'
 import {
   getLocalFactionIds,
   getLocalFactionMetadata,
@@ -138,7 +139,11 @@ export async function discoverFactions(): Promise<FactionDiscoveryEntry[]> {
       await pruneStaleStaticFactions(validCacheKeys)
     } catch (error) {
       console.error('Failed to load manifest:', error)
-      // Fall back to empty list - user can still use local factions
+      // Fall back to empty list - user can still use local factions.
+      // Worth reporting: manifestLoader only throws here when the network
+      // failed AND there is no cache, so the visitor sees a site with no
+      // factions at all. Offline visitors with a warm cache never reach this.
+      reportError(error, { stage: 'discoverFactions:manifest' })
     }
   }
 
@@ -150,6 +155,9 @@ export async function discoverFactions(): Promise<FactionDiscoveryEntry[]> {
     }
   } catch (error) {
     console.warn('Failed to load local factions:', error)
+    // Usually IndexedDB being unavailable (private browsing, storage pressure).
+    // Warning level: the rest of the site still works.
+    reportError(error, { stage: 'discoverFactions:local' }, 'warning')
   }
 
   return entries

--- a/web/src/services/modelLoader.ts
+++ b/web/src/services/modelLoader.ts
@@ -26,6 +26,7 @@
  */
 
 import { openDB, type DBSchema, type IDBPDatabase } from 'idb'
+import { reportError } from '@/lib/monitoring'
 import {
   ZipReader,
   HttpRangeReader,
@@ -420,6 +421,10 @@ export async function getFactionModelsIndex(
     // never absence. Detail stays in the console for developers; callers show a
     // generic message so internals never reach the UI.
     console.warn('Model index unavailable without a whole-bundle download', error)
+    // The UI deliberately discards this error (see UnitModelSection), so Sentry
+    // is the only place it can surface. The manifest promised a bundle, so this
+    // is a broken 3D viewer for the visitor, not simply "no model".
+    reportError(error, { stage: 'loadModelIndex', factionId, version })
     throw new ModelIndexUnavailableError(error)
   }
   // A bundle without its own index is corrupt, not empty.

--- a/web/src/services/modelLoader.ts
+++ b/web/src/services/modelLoader.ts
@@ -27,6 +27,13 @@
 
 import { openDB, type DBSchema, type IDBPDatabase } from 'idb'
 import { reportError } from '@/lib/monitoring'
+
+/**
+ * Model bundles whose index failure has already been reported this session,
+ * keyed by `${factionId}@${version}`. Prevents one broken bundle from emitting
+ * an event on every unit page the visitor opens.
+ */
+const reportedModelIndexFailures = new Set<string>()
 import {
   ZipReader,
   HttpRangeReader,
@@ -424,7 +431,18 @@ export async function getFactionModelsIndex(
     // The UI deliberately discards this error (see UnitModelSection), so Sentry
     // is the only place it can surface. The manifest promised a bundle, so this
     // is a broken 3D viewer for the visitor, not simply "no model".
-    reportError(error, { stage: 'loadModelIndex', factionId, version })
+    //
+    // Reported once per bundle per session: the failure is not cached (only the
+    // success path writes to IndexedDB) and `rangeSupport` latches to 'no' for
+    // the session, so without this guard a visitor behind a Range-stripping
+    // proxy would re-report on every unit page they open.
+    if (!reportedModelIndexFailures.has(cacheKey)) {
+      reportedModelIndexFailures.add(cacheKey)
+      reportError(error, {
+        context: { stage: 'loadModelIndex', factionId, version },
+        perVisitor: true,
+      })
+    }
     throw new ModelIndexUnavailableError(error)
   }
   // A bundle without its own index is corrupt, not empty.

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,6 +3,7 @@ import fs from 'fs'
 import { defineConfig, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import { sentryVitePlugin } from '@sentry/vite-plugin'
 
 /**
  * Check if a directory name looks like a semver version (e.g. "1.0.0", "2.1.3").
@@ -221,10 +222,106 @@ function serveFactionModels(): Plugin {
   }
 }
 
+/**
+ * Cloudflare Web Analytics beacon.
+ *
+ * Injected at build time only, and only when VITE_CF_BEACON_TOKEN is set, so
+ * the dev server never phones home and local page views never pollute the
+ * production numbers.
+ *
+ * `spa: true` is the default but stated explicitly: without it the beacon only
+ * records the initial page load, and every React Router navigation — which is
+ * every unit and faction page on this site — would be invisible.
+ *
+ * The token is not a secret; it is public in the deployed HTML by design.
+ */
+function cloudflareWebAnalytics(): Plugin {
+  return {
+    name: 'cloudflare-web-analytics',
+    apply: 'build',
+    transformIndexHtml(html) {
+      const token = process.env.VITE_CF_BEACON_TOKEN
+      if (!token) return html
+
+      // CF site tokens are 32 hex characters. A malformed token fails silently
+      // at runtime (no data, no error), so surface it at build time instead.
+      if (!/^[a-f0-9]{32}$/i.test(token)) {
+        console.warn(
+          `[cloudflare-web-analytics] VITE_CF_BEACON_TOKEN does not look like a ` +
+            `Cloudflare site token (expected 32 hex chars). Injecting anyway, but ` +
+            `analytics will silently collect nothing if it is wrong.`,
+        )
+      }
+
+      return {
+        html,
+        tags: [
+          {
+            tag: 'script',
+            attrs: {
+              defer: true,
+              src: 'https://static.cloudflareinsights.com/beacon.min.js',
+              'data-cf-beacon': JSON.stringify({ token, spa: true }),
+            },
+            injectTo: 'body',
+          },
+        ],
+      }
+    },
+  }
+}
+
+// Sourcemap upload only runs when a Sentry auth token is present, so PR builds
+// and local builds skip it entirely.
+const SENTRY_UPLOAD_ENABLED = Boolean(
+  process.env.SENTRY_AUTH_TOKEN && process.env.SENTRY_ORG && process.env.SENTRY_PROJECT,
+)
+
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [tailwindcss(), react(), serveFactions(), serveFactionModels()],
+  plugins: [
+    tailwindcss(),
+    react(),
+    serveFactions(),
+    serveFactionModels(),
+    cloudflareWebAnalytics(),
+    // Must come last: it needs the final bundle to inject debug IDs.
+    ...(SENTRY_UPLOAD_ENABLED
+      ? [
+          sentryVitePlugin({
+            org: process.env.SENTRY_ORG,
+            project: process.env.SENTRY_PROJECT,
+            authToken: process.env.SENTRY_AUTH_TOKEN,
+            release: { name: process.env.VITE_APP_VERSION },
+            // Don't send build telemetry to Sentry; we only want app errors.
+            telemetry: false,
+            sourcemaps: {
+              // Upload the maps to Sentry, then delete them from dist so they
+              // are never served publicly.
+              filesToDeleteAfterUpload: ['./dist/**/*.map'],
+            },
+            // By default the plugin throws and kills the build if the upload
+            // fails. A Sentry outage or an expired token must not block
+            // shipping the site — we lose readable stack traces for that
+            // release, nothing more. The deploy workflow strips any sourcemaps
+            // left behind by a failed upload.
+            errorHandler: err => {
+              console.warn(
+                `[sentry-vite-plugin] Sourcemap upload failed; continuing build. ` +
+                  `Stack traces for this release will be minified.\n${err.message}`,
+              )
+            },
+          }),
+        ]
+      : []),
+  ],
   base: '/',
+  build: {
+    // 'hidden' emits sourcemaps without the //# sourceMappingURL comment: the
+    // Sentry plugin matches them by debug ID, so stack traces resolve without
+    // pointing browsers (or anyone else) at the maps.
+    sourcemap: SENTRY_UPLOAD_ENABLED ? 'hidden' : false,
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -273,9 +273,24 @@ function cloudflareWebAnalytics(): Plugin {
 
 // Sourcemap upload only runs when a Sentry auth token is present, so PR builds
 // and local builds skip it entirely.
-const SENTRY_UPLOAD_ENABLED = Boolean(
-  process.env.SENTRY_AUTH_TOKEN && process.env.SENTRY_ORG && process.env.SENTRY_PROJECT,
-)
+// All three are required. sentry-cli can read the org out of an organization
+// auth token, but the Vite plugin checks for `org` itself before it ever calls
+// the CLI — without it the plugin logs a warning and silently skips the upload.
+const SENTRY_UPLOAD_VARS = ['SENTRY_AUTH_TOKEN', 'SENTRY_ORG', 'SENTRY_PROJECT'] as const
+const SENTRY_UPLOAD_ENABLED = SENTRY_UPLOAD_VARS.every(name => process.env[name])
+
+// A partial config otherwise fails silently: the build succeeds, no sourcemaps
+// are uploaded, and every stack trace in Sentry stays minified.
+if (!SENTRY_UPLOAD_ENABLED) {
+  const missing = SENTRY_UPLOAD_VARS.filter(name => !process.env[name])
+  if (missing.length < SENTRY_UPLOAD_VARS.length) {
+    console.warn(
+      `[sentry] Sourcemap upload disabled — missing ${missing.join(', ')}. ` +
+        `Stack traces will be minified until all of ` +
+        `${SENTRY_UPLOAD_VARS.join(', ')} are set.`,
+    )
+  }
+}
 
 // https://vite.dev/config/
 export default defineConfig({

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -307,6 +307,11 @@ export default defineConfig({
             org: process.env.SENTRY_ORG,
             project: process.env.SENTRY_PROJECT,
             authToken: process.env.SENTRY_AUTH_TOKEN,
+            // The plugin hardcodes https://sentry.io when unset, so EU-region
+            // orgs (DSNs containing `.de.`) must set SENTRY_URL to
+            // https://de.sentry.io or every upload 404s. Undefined keeps the
+            // plugin's US default.
+            url: process.env.SENTRY_URL || undefined,
             release: { name: process.env.VITE_APP_VERSION },
             // Don't send build telemetry to Sentry; we only want app errors.
             telemetry: false,


### PR DESCRIPTION
Adds free-tier error monitoring and traffic analytics to the deployed site. Previously there was neither: `ErrorBoundary` only wrote to the visitor's own console, so every crash a real user hit was invisible, and there were no traffic numbers at all.

**Nothing activates until the secrets below are added.** Without `VITE_SENTRY_DSN` Sentry never initialises; without `VITE_CF_BEACON_TOKEN` the beacon is not injected. Dev, tests, CI and forks send nothing.

## Sentry

- `initMonitoring()` runs in `main.tsx` before render, so first-paint errors are captured
- `ErrorBoundary` reports caught errors with the React component stack
- React 19 root hooks catch uncaught/recoverable errors — registered **only when a DSN is configured**, see "Debuggability" below
- `Routes` wrapped with `wrapReactRouterRouting` so transactions are named `/faction/:factionId/unit/:unitId` rather than one per unit
- Sourcemaps are generated only when `SENTRY_AUTH_TOKEN` is set, uploaded, then deleted from `dist/`
- `SENTRY_URL` is plumbed through for EU-region orgs — the bundler plugin hardcodes the US endpoint otherwise, and every upload silently fails

## Cloudflare Web Analytics

A beacon is injected at build time with `spa: true`, gated on `VITE_CF_BEACON_TOKEN`.

⚠️ **`CF_BEACON_TOKEN` should be left unset on this repo.** Zone-level RUM is already enabled for pa-pedia.com and Cloudflare auto-injects the beacon at the edge — Core Web Vitals are already reporting in the dashboard. Setting the secret would inject a second beacon and double-count every page view. The plugin stays as a fallback if the site ever moves off Cloudflare, or if explicit control over the `spa` flag is wanted.

## Reporting the failures that were being swallowed

Global handlers alone would have stayed quiet through this app's most user-visible failures, because they're caught, logged to console, and degraded gracefully. `reportError()` is now called where the visitor's experience is genuinely broken:

- **`factionLoader`** — manifest load failure (site shows zero factions). `manifestLoader` only throws when the network failed *and* there's no cache, so offline visitors with a warm cache don't trigger it
- **`factionLoader`** — local faction load failure, at `warning` level (IndexedDB unavailable in private browsing)
- **`modelLoader`** — model index unreadable when the manifest promised a bundle. `UnitModelSection` discards this error by design, so Sentry is the only place it can surface

Deliberately not reported: `zipHandler` parse failures (user-supplied files, already shown in the UI), the dev-only discovery probe, and offline manifest fetches that fall back to cache successfully.

## Free-tier guardrails

The Sentry free tier is 5,000 errors/month, so `filterEvent()` protects it:

- **Chunk-load errors sampled at 5%** and fingerprinted into a single issue. The stale-`index.html` failure documented in `web/public/_headers` throws one of these per stranded user, so a single bad deploy could otherwise exhaust the monthly quota in an afternoon
- **Outage-shaped failures sampled at 10%** via `reportError(err, { perVisitor: true })`. A missing manifest breaks the site for everyone at once and `discoverFactions` runs once per app mount, so this produced one full-rate event per visitor for the duration of the outage — the same quota risk as a chunk-load storm, on a path that initially bypassed the sampling. Applied to the manifest and model-index failures; the local-faction warning is left unsampled since its volume scales with affected browsers, not with an outage
- `modelLoader` reports an unreadable bundle once per session per bundle — the failure is never cached and `rangeSupport` latches for the session, so a visitor behind a Range-stripping proxy previously re-reported on every unit page
- Browser-extension and `ResizeObserver` noise dropped — never actionable
- Tracing sampled at 10%, tunable at deploy time via the `SENTRY_TRACES_SAMPLE_RATE` repository variable
- **No Session Replay** — 50/month is gone after one bad deploy, and it roughly doubles the SDK's bundle cost. There's a note in `monitoring.ts` on adding it
- `sendDefaultPii` off, so visitor IPs are never attached

## Debuggability

React's `defaultOnUncaughtError` routes through `reportGlobalError`, which logs to the console. `Sentry.reactErrorHandler()` with no callback captures and returns *without* logging. Registering it unconditionally therefore made local debugging strictly worse than before this PR: with no DSN — dev, CI, forks — `captureException` is a no-op, so an error thrown outside `ErrorBoundary` produced a blank page and an empty console.

The hooks are now registered only when a DSN is configured. Passing a logging callback is not an alternative — it flips the SDK's `mechanism.handled` to `true` and mislabels genuinely unhandled errors.

`onCaughtError` stays unregistered in both cases: `ErrorBoundary` already reports those with component context, and both would double-count.

## Two failure-mode decisions

**Sourcemap upload failure warns instead of failing the build.** The Sentry plugin defaults to throwing, which would mean a Sentry outage or an expired token blocks deploying faction data. Now the build continues (that release gets minified traces) and the workflow strips any maps a failed upload left behind — verified a build with bad credentials exits 0 and leaves zero `.map` files.

**Partial configuration warns rather than failing silently.** Setting some but not all of `SENTRY_AUTH_TOKEN` / `SENTRY_ORG` / `SENTRY_PROJECT` previously disabled upload with no indication; every stack trace would stay minified with nothing to explain why.

## Testing

- 944 unit tests pass (31 new, covering event filtering, sample-rate parsing, per-visitor sampling, non-`Error` hints, and the load-bearing property that `initMonitoring` no-ops without a DSN)
- 85 Playwright e2e tests pass
- Lint and `tsc` clean
- Bundle grows **8.7 KB gzipped** (502.83 → 511.51 KB), measured against a stashed baseline

Verified by building rather than by reading: the beacon token cannot break out of its HTML attribute (tested with `ab"><script>`), and no `.map` file reaches `dist` under any credential state.

## Required before this does anything

Repository secrets: `SENTRY_DSN`, `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_URL`, `SENTRY_AUTH_TOKEN`. Full setup steps are in the new README "Monitoring" section.

`CF_BEACON_TOKEN` should be left unset — see the Cloudflare section above.