### PR TITLE
Prevent unhandled IndexedDB transaction rejections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,6 +315,12 @@ fall back to cache successfully.
   and both would double-count against the 5k/month quota.
 - Keep chunk-load sampling in `filterEvent()`. Without it, one stale-deploy incident
   (see `web/public/_headers`) floods the quota.
+- Keep the IndexedDB teardown drop in `filterEvent()`. When the browser force-closes
+  the origin's storage, `idb`'s read shortcuts (`db.get`, `db.getAllKeys`) leave their
+  `tx.done` rejection unobserved, so it lands as a stackless `AbortError: AbortError`.
+  Unactionable, and a duplicate of what `factionLoader`'s catch sites already report.
+  Our own transactions call `claimTransactionDone()` (`web/src/services/idbTransaction.ts`)
+  instead — call it on every new transaction, before the first `await`.
 - Sentry's beforeSend logic is pure and unit-tested in `web/src/lib/__tests__/monitoring.test.ts` —
   extend those tests when changing filters.
 - Adding new tracked routes? They're derived from the `<Route>` tree automatically; no manual

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,7 +286,10 @@ no beacon token means the analytics script isn't injected. Dev, tests and CI sen
 **Files**:
 - `web/src/lib/monitoring.ts` - Sentry init, event filtering, `reportError()` helper
 - `web/vite.config.ts` - `cloudflareWebAnalytics()` beacon injection + `sentryVitePlugin` sourcemap upload
-- `web/src/main.tsx` - `initMonitoring()` before render; React 19 root error hooks
+- `web/src/instrument.ts` - calls `initMonitoring()`; imported first by `main.tsx`
+  **before `./App.tsx`**, because App wraps the router at module scope and ESM
+  evaluates it first — init any later and the wrapper silently no-ops
+- `web/src/main.tsx` - imports `./instrument`, then React 19 root error hooks
 - `web/src/App.tsx` - `Sentry.wrapReactRouterRouting(Routes)` for parameterised route names
 - `web/src/components/ErrorBoundary.tsx` - reports caught errors with component stack
 - `reportError(err, { perVisitor: true })` marks outage-shaped failures, which `filterEvent`
@@ -319,6 +322,9 @@ fall back to cache successfully.
   the origin's storage, `idb`'s read shortcuts (`db.get`, `db.getAllKeys`) leave their
   `tx.done` rejection unobserved, so it lands as a stackless `AbortError: AbortError`.
   Unactionable, and a duplicate of what `factionLoader`'s catch sites already report.
+  It is gated on `isUnhandled()` for exactly that reason: a force-close rejects the
+  deliberate `reportError()` path with the same message, and dropping that too would
+  leave real storage failures invisible. Don't match on the message alone.
   Our own transactions call `claimTransactionDone()` (`web/src/services/idbTransaction.ts`)
   instead — call it on every new transaction, before the first `await`.
 - Sentry's beforeSend logic is pure and unit-tested in `web/src/lib/__tests__/monitoring.test.ts` —

--- a/web/src/__tests__/instrumentOrder.test.ts
+++ b/web/src/__tests__/instrumentOrder.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+/**
+ * Pins the import order in main.tsx.
+ *
+ * `App.tsx` wraps the router with Sentry at module scope, and that wrapper is a
+ * silent no-op unless `Sentry.init` has already run: it returns `Routes`
+ * unchanged, and the only symptom is missing navigation transactions in a
+ * dashboard nobody checks daily. ESM evaluates imports in source order, so the
+ * side-effecting './instrument' import has to come before './App'.
+ *
+ * Asserting on source text is blunt, but the alternative is no protection at
+ * all — reordering these imports breaks nothing that any other test can see.
+ */
+describe('main.tsx bootstrap order', () => {
+  it('imports ./instrument before ./App', () => {
+    const source = readFileSync(resolve(__dirname, '../main.tsx'), 'utf8')
+
+    const instrumentAt = source.indexOf(`'./instrument'`)
+    const appAt = source.indexOf(`'./App`)
+
+    expect(instrumentAt).toBeGreaterThanOrEqual(0)
+    expect(appAt).toBeGreaterThanOrEqual(0)
+    expect(instrumentAt).toBeLessThan(appAt)
+  })
+})

--- a/web/src/instrument.ts
+++ b/web/src/instrument.ts
@@ -1,0 +1,19 @@
+/**
+ * Sentry initialisation, isolated so it runs before anything that touches the
+ * SDK at module scope.
+ *
+ * `App.tsx` calls `Sentry.wrapReactRouterRouting(Routes)` while its module body
+ * evaluates, and ESM evaluates imported modules before the importing module's
+ * statements — so calling `initMonitoring()` from main.tsx's body was always
+ * too late. The wrapper found no router integration registered yet and returned
+ * `Routes` untouched, which fails silently: no navigation transactions, and
+ * pageloads named by raw URL (`/faction/mla/unit/tank`) instead of the
+ * parameterised route, so every unit page became its own transaction.
+ *
+ * main.tsx must import this module before './App.tsx'. There is a test in
+ * src/__tests__/instrumentOrder.test.ts pinning that order, because nothing
+ * else fails when it regresses.
+ */
+import { initMonitoring } from '@/lib/monitoring'
+
+initMonitoring()

--- a/web/src/lib/__tests__/monitoring.test.ts
+++ b/web/src/lib/__tests__/monitoring.test.ts
@@ -8,11 +8,26 @@ import {
   parseSampleRate,
 } from '../monitoring'
 
-/** Minimal Sentry error event carrying a single exception value. */
+/**
+ * Minimal Sentry error event carrying a single exception value.
+ *
+ * No mechanism, which is how `captureException` events arrive unless the SDK
+ * marks them otherwise — i.e. a handled report.
+ */
 function errorEvent(type: string, value: string): ErrorEvent {
   return {
     type: undefined,
     exception: { values: [{ type, value }] },
+  } as ErrorEvent
+}
+
+/** As above, but flagged the way global handlers (onunhandledrejection) mark events. */
+function unhandledEvent(type: string, value: string): ErrorEvent {
+  return {
+    type: undefined,
+    exception: {
+      values: [{ type, value, mechanism: { type: 'onunhandledrejection', handled: false } }],
+    },
   } as ErrorEvent
 }
 
@@ -127,17 +142,30 @@ describe('filterEvent', () => {
     expect(result?.fingerprint).toBeUndefined()
   })
 
-  it('drops IndexedDB teardown noise unconditionally', () => {
-    const aborted = errorEvent('AbortError', 'AbortError')
-    const forceClosed = errorEvent(
+  it('drops unhandled IndexedDB teardown noise', () => {
+    const aborted = unhandledEvent('AbortError', 'AbortError')
+    const forceClosed = unhandledEvent(
       'UnknownError',
       'Connection is closing because of: Force close delete origin',
     )
 
-    // Not sampled: the failure the visitor feels is already reported from the
-    // catch sites in factionLoader, so these are pure duplicates.
+    // Not sampled: these escaped from a global handler and duplicate what the
+    // catch sites in factionLoader already report.
     expect(filterEvent(aborted, undefined, () => 0)).toBeNull()
     expect(filterEvent(forceClosed, undefined, () => 0)).toBeNull()
+  })
+
+  // The whole point of the teardown filter is that the deliberate report
+  // survives. A force-close rejects getLocalFactionIds() with exactly this
+  // message, and factionLoader reports it via reportError — dropping that too
+  // would leave real storage failures invisible.
+  it('keeps the deliberate reportError for the same failure', () => {
+    const reported = errorEvent(
+      'UnknownError',
+      'Connection is closing because of: Force close delete origin',
+    )
+
+    expect(filterEvent(reported, undefined, () => 0)).toBe(reported)
   })
 
   it('drops chunk-load errors outside the sample rate', () => {

--- a/web/src/lib/__tests__/monitoring.test.ts
+++ b/web/src/lib/__tests__/monitoring.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import type { ErrorEvent, EventHint } from '@sentry/react'
 import {
   isChunkLoadError,
+  isIdbTeardownError,
   eventMessage,
   filterEvent,
   parseSampleRate,
@@ -32,6 +33,31 @@ describe('isChunkLoadError', () => {
     expect(isChunkLoadError('Cannot read properties of undefined')).toBe(false)
     expect(isChunkLoadError('QuotaExceededError: IndexedDB is full')).toBe(false)
     expect(isChunkLoadError('Failed to fetch')).toBe(false)
+  })
+})
+
+describe('isIdbTeardownError', () => {
+  // Both messages came off one page load in Sentry (PA-PEDIA-2 / PA-PEDIA-3):
+  // Chromium force-closed the origin's storage under two open transactions.
+  it('matches the messages Chromium emits when it force-closes storage', () => {
+    expect(
+      isIdbTeardownError(
+        'UnknownError: Connection is closing because of: Force close delete origin',
+      ),
+    ).toBe(true)
+  })
+
+  // idb's fallback when the transaction aborted without setting tx.error.
+  it("matches idb's stackless tx.done rejection", () => {
+    expect(isIdbTeardownError('AbortError: AbortError')).toBe(true)
+  })
+
+  it('leaves other IndexedDB failures alone', () => {
+    expect(isIdbTeardownError('QuotaExceededError: quota exceeded')).toBe(false)
+    // A real fetch/user abort carries a descriptive message, unlike idb's.
+    expect(
+      isIdbTeardownError('AbortError: The user aborted a request'),
+    ).toBe(false)
   })
 })
 
@@ -99,6 +125,19 @@ describe('filterEvent', () => {
 
     expect(result).toBe(event)
     expect(result?.fingerprint).toBeUndefined()
+  })
+
+  it('drops IndexedDB teardown noise unconditionally', () => {
+    const aborted = errorEvent('AbortError', 'AbortError')
+    const forceClosed = errorEvent(
+      'UnknownError',
+      'Connection is closing because of: Force close delete origin',
+    )
+
+    // Not sampled: the failure the visitor feels is already reported from the
+    // catch sites in factionLoader, so these are pure duplicates.
+    expect(filterEvent(aborted, undefined, () => 0)).toBeNull()
+    expect(filterEvent(forceClosed, undefined, () => 0)).toBeNull()
   })
 
   it('drops chunk-load errors outside the sample rate', () => {

--- a/web/src/lib/monitoring.ts
+++ b/web/src/lib/monitoring.ts
@@ -91,6 +91,20 @@ export function isIdbTeardownError(message: string): boolean {
   )
 }
 
+/**
+ * Whether the SDK captured this event from a global handler rather than from a
+ * `captureException` call.
+ *
+ * Load-bearing for the teardown filter below: a force-close rejects our own
+ * `reportError` path with the very same message, and `beforeSend` sees handled
+ * and unhandled events alike. Matching on the message alone would drop the
+ * deliberate report too, leaving the storage-teardown failure invisible —
+ * the opposite of what that filter is for.
+ */
+export function isUnhandled(event: ErrorEvent): boolean {
+  return event.exception?.values?.some(v => v.mechanism?.handled === false) ?? false
+}
+
 /** Extracts a searchable message from a Sentry event and its original error. */
 export function eventMessage(event: ErrorEvent, hint?: EventHint): string {
   const values = event.exception?.values ?? []
@@ -117,7 +131,9 @@ export function filterEvent(
 ): ErrorEvent | null {
   const message = eventMessage(event, hint)
 
-  if (isIdbTeardownError(message)) return null
+  // Only the escaped duplicates. Handled events reach here too, and the
+  // reportError() call in factionLoader's catch site carries this same message.
+  if (isUnhandled(event) && isIdbTeardownError(message)) return null
 
   if (isChunkLoadError(message)) {
     if (random() >= CHUNK_LOAD_SAMPLE_RATE) return null

--- a/web/src/lib/monitoring.ts
+++ b/web/src/lib/monitoring.ts
@@ -70,6 +70,27 @@ export function isChunkLoadError(message: string): boolean {
   )
 }
 
+/**
+ * Detects rejections thrown when the browser tears IndexedDB down underneath an
+ * open transaction — site data cleared, or the origin evicted under storage
+ * pressure. Chromium aborts every in-flight transaction with "Connection is
+ * closing because of: <reason>"; `idb` then rejects each transaction's `done`
+ * promise, falling back to a bare `AbortError: AbortError` when the abort left
+ * `tx.error` unset.
+ *
+ * Unactionable, and already covered: the failure the visitor actually feels is
+ * reported deliberately from the catch sites in factionLoader. These are the
+ * duplicate. We suppress our own leak of `tx.done` (see idbTransaction.ts), but
+ * `idb`'s read shortcuts (`db.get`, `db.getAllKeys`) never attach a handler to
+ * it at all — that one is inside the library, so it has to be filtered here.
+ */
+export function isIdbTeardownError(message: string): boolean {
+  return (
+    /AbortError: AbortError/.test(message) ||
+    /Connection is closing because of:/i.test(message)
+  )
+}
+
 /** Extracts a searchable message from a Sentry event and its original error. */
 export function eventMessage(event: ErrorEvent, hint?: EventHint): string {
   const values = event.exception?.values ?? []
@@ -95,6 +116,8 @@ export function filterEvent(
   random: () => number = Math.random,
 ): ErrorEvent | null {
   const message = eventMessage(event, hint)
+
+  if (isIdbTeardownError(message)) return null
 
   if (isChunkLoadError(message)) {
     if (random() >= CHUNK_LOAD_SAMPLE_RATE) return null

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,12 +1,14 @@
+// MUST be first: initialises Sentry before App.tsx's module body wraps the
+// router. See instrument.ts — calling initMonitoring() from here instead is
+// too late, and fails silently.
+import './instrument'
+
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import * as Sentry from '@sentry/react'
 import './index.css'
 import App from './App.tsx'
-import { initMonitoring, isMonitoringEnabled } from '@/lib/monitoring'
-
-// Before render, so errors thrown during the first paint are captured.
-initMonitoring()
+import { isMonitoringEnabled } from '@/lib/monitoring'
 
 // React 19 root error hooks, registered ONLY when Sentry can receive the error.
 //

--- a/web/src/services/__tests__/factionStorageTransactions.test.ts
+++ b/web/src/services/__tests__/factionStorageTransactions.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest'
+
+/**
+ * Every write path in the two IndexedDB services opens a transaction, awaits the
+ * individual requests, and awaits `tx.done` last. When the browser tears storage
+ * down mid-write, the requests reject and we throw before reaching that final
+ * await — so `tx.done`, which `idb` created eagerly, is left rejected and
+ * unobserved. These tests drive that exact shape through each function and
+ * assert nothing escapes to the global rejection handler.
+ */
+
+/** A transaction whose requests and `done` promise both reject immediately. */
+function makeAbortingTransaction() {
+  const opError = new DOMException(
+    'Connection is closing because of: Force close delete origin',
+    'UnknownError',
+  )
+  const store = {
+    put: () => Promise.reject(opError),
+    delete: () => Promise.reject(opError),
+    clear: () => Promise.reject(opError),
+    getAllKeys: () => Promise.reject(opError),
+  }
+  return {
+    // idb's fallback when the transaction aborted without setting tx.error.
+    done: Promise.reject(new DOMException('AbortError', 'AbortError')),
+    objectStore: () => store,
+  }
+}
+
+vi.mock('idb', () => ({
+  openDB: () =>
+    Promise.resolve({
+      // A fresh transaction per call, so the module-level db promise the
+      // services cache can be reused across tests.
+      transaction: () => makeAbortingTransaction(),
+    }),
+}))
+
+async function collectUnhandledRejections(run: () => Promise<void>): Promise<string[]> {
+  const seen: string[] = []
+  const onRejection = (reason: unknown) => {
+    const err = reason as { name?: string; message?: string }
+    seen.push(`${err?.name}: ${err?.message}`)
+  }
+
+  process.on('unhandledRejection', onRejection)
+  try {
+    await run()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  } finally {
+    process.off('unhandledRejection', onRejection)
+  }
+  return seen
+}
+
+/** Runs an operation expected to reject, and reports what leaked meanwhile. */
+async function leakedRejections(op: () => Promise<unknown>): Promise<string[]> {
+  return collectUnhandledRejections(async () => {
+    await expect(op()).rejects.toThrow()
+  })
+}
+
+describe('static faction cache transactions', () => {
+  it('cacheStaticFaction does not leak tx.done on abort', async () => {
+    const { cacheStaticFaction } = await import('../staticFactionCache')
+
+    const leaked = await leakedRejections(() =>
+      cacheStaticFaction(
+        'mla',
+        '1.0.0',
+        20260727000000,
+        {} as never,
+        {} as never,
+        new Map([['assets/pa/units/land/tank/tank.json', new Blob(['{}'])]]),
+      ),
+    )
+
+    expect(leaked).toEqual([])
+  })
+
+  it('deleteStaticFactionCache does not leak tx.done on abort', async () => {
+    const { deleteStaticFactionCache } = await import('../staticFactionCache')
+    expect(await leakedRejections(() => deleteStaticFactionCache('mla'))).toEqual([])
+  })
+
+  it('clearStaticFactionCache does not leak tx.done on abort', async () => {
+    const { clearStaticFactionCache } = await import('../staticFactionCache')
+    expect(await leakedRejections(() => clearStaticFactionCache())).toEqual([])
+  })
+})
+
+describe('local faction storage transactions', () => {
+  it('saveLocalFaction does not leak tx.done on abort', async () => {
+    const { saveLocalFaction } = await import('../localFactionStorage')
+
+    const leaked = await leakedRejections(() =>
+      saveLocalFaction('my-faction', {} as never, {} as never, new Map()),
+    )
+
+    expect(leaked).toEqual([])
+  })
+
+  it('deleteLocalFaction does not leak tx.done on abort', async () => {
+    const { deleteLocalFaction } = await import('../localFactionStorage')
+    expect(await leakedRejections(() => deleteLocalFaction('my-faction'))).toEqual([])
+  })
+})

--- a/web/src/services/__tests__/idbTransaction.test.ts
+++ b/web/src/services/__tests__/idbTransaction.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { openDB, type IDBPDatabase } from 'idb'
+import { claimTransactionDone } from '../idbTransaction'
+
+/**
+ * Captures unhandled promise rejections for the duration of `run`.
+ *
+ * Node reports these on `process`, not on jsdom's window, and only at the end
+ * of a macrotask — hence the `setTimeout` drain rather than a microtask flush.
+ */
+async function collectUnhandledRejections(run: () => Promise<void>): Promise<string[]> {
+  const seen: string[] = []
+  const onRejection = (reason: unknown) => {
+    const err = reason as { name?: string; message?: string }
+    seen.push(`${err?.name}: ${err?.message}`)
+  }
+
+  // Vitest installs its own handler; ours runs alongside it.
+  process.on('unhandledRejection', onRejection)
+  try {
+    await run()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  } finally {
+    process.off('unhandledRejection', onRejection)
+  }
+  return seen
+}
+
+let dbCounter = 0
+
+async function openTestDB(): Promise<IDBPDatabase> {
+  return openDB(`idb-transaction-test-${dbCounter++}`, 1, {
+    upgrade(db) {
+      db.createObjectStore('factions', { keyPath: 'id' })
+      db.createObjectStore('assets')
+    },
+  })
+}
+
+describe('claimTransactionDone', () => {
+  let db: IDBPDatabase | null = null
+
+  afterEach(() => {
+    db?.close()
+    db = null
+  })
+
+  /**
+   * Locks in the failure mode this helper exists for. Without the claim, a
+   * transaction that aborts mid-write leaves `tx.done` rejected and unobserved,
+   * which is what reached Sentry as a stackless "AbortError: AbortError".
+   */
+  it('reproduces the unhandled rejection when tx.done is left unclaimed', async () => {
+    const seen = await collectUnhandledRejections(async () => {
+      db = await openTestDB()
+      try {
+        const tx = db.transaction(['factions', 'assets'], 'readwrite')
+        const put = tx.objectStore('factions').put({ id: 'mla' })
+        tx.abort() // storage yanked out from under an in-flight write
+        await put
+        await tx.done // never reached
+      } catch {
+        // The app's catch sites swallow this and degrade gracefully.
+      }
+    })
+
+    expect(seen).toContain('AbortError: AbortError')
+  })
+
+  it('prevents the unhandled rejection when the transaction is claimed', async () => {
+    const seen = await collectUnhandledRejections(async () => {
+      db = await openTestDB()
+      try {
+        const tx = db.transaction(['factions', 'assets'], 'readwrite')
+        claimTransactionDone(tx)
+        const put = tx.objectStore('factions').put({ id: 'mla' })
+        tx.abort()
+        await put
+        await tx.done
+      } catch {
+        // Same graceful degradation; the difference is what escapes to the
+        // global handler.
+      }
+    })
+
+    expect(seen).toEqual([])
+  })
+
+  it('still surfaces the abort to a caller that awaits tx.done', async () => {
+    db = await openTestDB()
+    const tx = db.transaction(['factions', 'assets'], 'readwrite')
+    claimTransactionDone(tx)
+    tx.abort()
+
+    // Claiming marks the rejection handled; it does not swallow it.
+    await expect(tx.done).rejects.toThrow()
+  })
+
+  it('leaves a committing transaction untouched', async () => {
+    db = await openTestDB()
+    const tx = db.transaction(['factions', 'assets'], 'readwrite')
+    claimTransactionDone(tx)
+    await tx.objectStore('factions').put({ id: 'mla' })
+    await expect(tx.done).resolves.toBeUndefined()
+
+    await expect(db.get('factions', 'mla')).resolves.toEqual({ id: 'mla' })
+  })
+})

--- a/web/src/services/idbTransaction.ts
+++ b/web/src/services/idbTransaction.ts
@@ -1,0 +1,30 @@
+/**
+ * IndexedDB transaction helpers.
+ */
+
+/**
+ * Marks a transaction's `done` promise as handled.
+ *
+ * `idb` creates `tx.done` eagerly — the moment `db.transaction()` is wrapped,
+ * long before our code reaches `await tx.done` at the end of a write. If an
+ * earlier request in that transaction rejects, we throw out of the function and
+ * never reach the `await`, leaving an already-rejected `tx.done` with no
+ * handler. It then surfaces as an unhandled rejection with no stack and no
+ * useful message: `AbortError: AbortError`, which is what `idb` rejects with
+ * when the transaction aborted without setting `tx.error`.
+ *
+ * The trigger in the wild is the browser tearing storage down underneath an
+ * open transaction (site data cleared, origin evicted under storage pressure) —
+ * Chromium aborts every in-flight transaction with "Connection is closing
+ * because of: Force close delete origin".
+ *
+ * Attaching a no-op handler drops only the duplicate. `.catch()` returns a new
+ * promise and leaves `tx.done` itself untouched, so the real failure still
+ * propagates through the awaited request, and a later `await tx.done` still
+ * observes commit-time errors.
+ *
+ * Call this immediately after creating a transaction, before the first `await`.
+ */
+export function claimTransactionDone(tx: { done: Promise<void> }): void {
+  tx.done.catch(() => {})
+}

--- a/web/src/services/localFactionStorage.ts
+++ b/web/src/services/localFactionStorage.ts
@@ -1,5 +1,6 @@
 import { openDB, type DBSchema, type IDBPDatabase } from 'idb'
 import type { FactionMetadata, FactionIndex } from '@/types/faction'
+import { claimTransactionDone } from './idbTransaction'
 
 interface LocalFactionDB extends DBSchema {
   factions: {
@@ -84,6 +85,7 @@ export async function saveLocalFaction(
 ): Promise<void> {
   const db = await getDB()
   const tx = db.transaction(['factions', 'assets'], 'readwrite')
+  claimTransactionDone(tx)
 
   // Save faction data
   await tx.objectStore('factions').put({
@@ -109,6 +111,7 @@ export async function saveLocalFaction(
 export async function deleteLocalFaction(factionId: string): Promise<void> {
   const db = await getDB()
   const tx = db.transaction(['factions', 'assets'], 'readwrite')
+  claimTransactionDone(tx)
 
   // Delete faction data
   await tx.objectStore('factions').delete(factionId)

--- a/web/src/services/modelLoader.ts
+++ b/web/src/services/modelLoader.ts
@@ -27,6 +27,7 @@
 
 import { openDB, type DBSchema, type IDBPDatabase } from 'idb'
 import { reportError } from '@/lib/monitoring'
+import { claimTransactionDone } from './idbTransaction'
 
 /**
  * Model bundles whose index failure has already been reported this session,
@@ -607,6 +608,7 @@ export async function clearModelCache(): Promise<void> {
   rangeSupport = 'unknown'
   const db = await getDB()
   const tx = db.transaction(['indexes', 'units', 'bundles'], 'readwrite')
+  claimTransactionDone(tx)
   await tx.objectStore('indexes').clear()
   await tx.objectStore('units').clear()
   await tx.objectStore('bundles').clear()

--- a/web/src/services/staticFactionCache.ts
+++ b/web/src/services/staticFactionCache.ts
@@ -12,6 +12,7 @@
 
 import { openDB, type DBSchema, type IDBPDatabase } from 'idb'
 import type { FactionMetadata, FactionIndex } from '@/types/faction'
+import { claimTransactionDone } from './idbTransaction'
 
 interface StaticFactionDB extends DBSchema {
   factions: {
@@ -111,6 +112,7 @@ export async function cacheStaticFaction(
 ): Promise<void> {
   const db = await getDB()
   const tx = db.transaction(['factions', 'assets'], 'readwrite')
+  claimTransactionDone(tx)
 
   // Save faction data
   await tx.objectStore('factions').put({
@@ -187,6 +189,7 @@ export async function getAllStaticAssets(cacheKey: string): Promise<Map<string, 
 export async function deleteStaticFactionCache(factionId: string): Promise<void> {
   const db = await getDB()
   const tx = db.transaction(['factions', 'assets'], 'readwrite')
+  claimTransactionDone(tx)
 
   // Delete faction data
   await tx.objectStore('factions').delete(factionId)
@@ -255,6 +258,7 @@ export async function getCachedManifestInfo(): Promise<{
 export async function clearStaticFactionCache(): Promise<void> {
   const db = await getDB()
   const tx = db.transaction(['factions', 'assets', 'manifest'], 'readwrite')
+  claimTransactionDone(tx)
   await tx.objectStore('factions').clear()
   await tx.objectStore('assets').clear()
   await tx.objectStore('manifest').clear()

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import fs from 'fs'
-import { defineConfig, type Plugin } from 'vite'
+import { defineConfig, loadEnv, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { sentryVitePlugin } from '@sentry/vite-plugin'
@@ -174,9 +174,6 @@ function devContentType(ext: string): string {
   return contentTypes[ext] || 'application/octet-stream'
 }
 
-/** `just dev-live`: dev server backed by real production faction data. */
-const DEV_LIVE = process.env.VITE_USE_LIVE_DATA === 'true'
-
 /** Production origin that dev-live borrows faction + model data from. */
 const PRODUCTION_ORIGIN = 'https://pa-pedia.com'
 
@@ -194,9 +191,9 @@ const PRODUCTION_ORIGIN = 'https://pa-pedia.com'
  * Can be overridden via VITE_FACTION_MODELS_DIR (e.g. for E2E fixtures).
  *
  * Skipped in dev-live, where model bundles come from production via the proxy
- * below rather than from local files (see DEV_LIVE).
+ * below rather than from local files (see the `devLive` argument).
  */
-function serveFactionModels(): Plugin {
+function serveFactionModels(devLive: boolean): Plugin {
   const modelsDir = path.resolve(__dirname, process.env.VITE_FACTION_MODELS_DIR || '../faction-models')
 
   return {
@@ -204,7 +201,7 @@ function serveFactionModels(): Plugin {
     configureServer(server) {
       // dev-live serves these from production through the proxy; local files
       // must not shadow it.
-      if (DEV_LIVE) return
+      if (devLive) return
 
       server.middlewares.use('/faction-models', (req, res, next) => {
         const reqUrl = req.url || ''
@@ -277,99 +274,114 @@ function cloudflareWebAnalytics(): Plugin {
 // auth token, but the Vite plugin checks for `org` itself before it ever calls
 // the CLI — without it the plugin logs a warning and silently skips the upload.
 const SENTRY_UPLOAD_VARS = ['SENTRY_AUTH_TOKEN', 'SENTRY_ORG', 'SENTRY_PROJECT'] as const
-const SENTRY_UPLOAD_ENABLED = SENTRY_UPLOAD_VARS.every(name => process.env[name])
-
-// A partial config otherwise fails silently: the build succeeds, no sourcemaps
-// are uploaded, and every stack trace in Sentry stays minified.
-if (!SENTRY_UPLOAD_ENABLED) {
-  const missing = SENTRY_UPLOAD_VARS.filter(name => !process.env[name])
-  if (missing.length < SENTRY_UPLOAD_VARS.length) {
-    console.warn(
-      `[sentry] Sourcemap upload disabled — missing ${missing.join(', ')}. ` +
-        `Stack traces will be minified until all of ` +
-        `${SENTRY_UPLOAD_VARS.join(', ')} are set.`,
-    )
-  }
-}
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [
-    tailwindcss(),
-    react(),
-    serveFactions(),
-    serveFactionModels(),
-    cloudflareWebAnalytics(),
-    // Must come last: it needs the final bundle to inject debug IDs.
-    ...(SENTRY_UPLOAD_ENABLED
-      ? [
-          sentryVitePlugin({
-            org: process.env.SENTRY_ORG,
-            project: process.env.SENTRY_PROJECT,
-            authToken: process.env.SENTRY_AUTH_TOKEN,
-            // The plugin hardcodes https://sentry.io when unset, so EU-region
-            // orgs (DSNs containing `.de.`) must set SENTRY_URL to
-            // https://de.sentry.io or every upload 404s. Undefined keeps the
-            // plugin's US default.
-            url: process.env.SENTRY_URL || undefined,
-            release: { name: process.env.VITE_APP_VERSION },
-            // Don't send build telemetry to Sentry; we only want app errors.
-            telemetry: false,
-            sourcemaps: {
-              // Upload the maps to Sentry, then delete them from dist so they
-              // are never served publicly.
-              filesToDeleteAfterUpload: ['./dist/**/*.map'],
-            },
-            // By default the plugin throws and kills the build if the upload
-            // fails. A Sentry outage or an expired token must not block
-            // shipping the site — we lose readable stack traces for that
-            // release, nothing more. The deploy workflow strips any sourcemaps
-            // left behind by a failed upload.
-            errorHandler: err => {
-              console.warn(
-                `[sentry-vite-plugin] Sourcemap upload failed; continuing build. ` +
-                  `Stack traces for this release will be minified.\n${err.message}`,
-              )
-            },
-          }),
-        ]
-      : []),
-  ],
-  base: '/',
-  build: {
-    // 'hidden' emits sourcemaps without the //# sourceMappingURL comment: the
-    // Sentry plugin matches them by debug ID, so stack traces resolve without
-    // pointing browsers (or anyone else) at the maps.
-    sourcemap: SENTRY_UPLOAD_ENABLED ? 'hidden' : false,
-  },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
+export default defineConfig(({ mode }) => {
+  // Vite exposes .env files to client code via import.meta.env, but it never
+  // populates process.env from them — that only ever holds real shell vars.
+  // Config-time reads therefore miss the `web/.env.local` setup documented in
+  // .env.example entirely, and fail silently: no beacon, no sourcemap upload,
+  // and VITE_USE_LIVE_DATA desyncing from the app code that reads it via
+  // import.meta.env. Merge the files in once, with shell vars still winning so
+  // CI (which sets them for real) is unaffected.
+  Object.assign(process.env, { ...loadEnv(mode, __dirname, ''), ...process.env })
+
+  /** `just dev-live`: dev server backed by real production faction data. */
+  const devLive = process.env.VITE_USE_LIVE_DATA === 'true'
+
+  const sentryUploadEnabled = SENTRY_UPLOAD_VARS.every(name => process.env[name])
+
+  // A partial config otherwise fails silently: the build succeeds, no sourcemaps
+  // are uploaded, and every stack trace in Sentry stays minified.
+  if (!sentryUploadEnabled) {
+    const missing = SENTRY_UPLOAD_VARS.filter(name => !process.env[name])
+    if (missing.length < SENTRY_UPLOAD_VARS.length) {
+      console.warn(
+        `[sentry] Sourcemap upload disabled — missing ${missing.join(', ')}. ` +
+          `Stack traces will be minified until all of ` +
+          `${SENTRY_UPLOAD_VARS.join(', ')} are set.`,
+      )
+    }
+  }
+
+  return {
+    plugins: [
+      tailwindcss(),
+      react(),
+      serveFactions(),
+      serveFactionModels(devLive),
+      cloudflareWebAnalytics(),
+      // Must come last: it needs the final bundle to inject debug IDs.
+      ...(sentryUploadEnabled
+        ? [
+            sentryVitePlugin({
+              org: process.env.SENTRY_ORG,
+              project: process.env.SENTRY_PROJECT,
+              authToken: process.env.SENTRY_AUTH_TOKEN,
+              // The plugin hardcodes https://sentry.io when unset, so EU-region
+              // orgs (DSNs containing `.de.`) must set SENTRY_URL to
+              // https://de.sentry.io or every upload 404s. Undefined keeps the
+              // plugin's US default.
+              url: process.env.SENTRY_URL || undefined,
+              release: { name: process.env.VITE_APP_VERSION },
+              // Don't send build telemetry to Sentry; we only want app errors.
+              telemetry: false,
+              sourcemaps: {
+                // Upload the maps to Sentry, then delete them from dist so they
+                // are never served publicly.
+                filesToDeleteAfterUpload: ['./dist/**/*.map'],
+              },
+              // By default the plugin throws and kills the build if the upload
+              // fails. A Sentry outage or an expired token must not block
+              // shipping the site — we lose readable stack traces for that
+              // release, nothing more. The deploy workflow strips any sourcemaps
+              // left behind by a failed upload.
+              errorHandler: err => {
+                console.warn(
+                  `[sentry-vite-plugin] Sourcemap upload failed; continuing build. ` +
+                    `Stack traces for this release will be minified.\n${err.message}`,
+                )
+              },
+            }),
+          ]
+        : []),
+    ],
+    base: '/',
+    build: {
+      // 'hidden' emits sourcemaps without the //# sourceMappingURL comment: the
+      // Sentry plugin matches them by debug ID, so stack traces resolve without
+      // pointing browsers (or anyone else) at the maps.
+      sourcemap: sentryUploadEnabled ? 'hidden' : false,
     },
-  },
-  server: {
-    // Bind to all addresses (required for Docker container access)
-    host: true,
-    fs: {
-      // Allow serving files from the factions folder at repo root
-      allow: ['..'],
-    },
-    // dev-live reads model bundles from production. Fetching them cross-origin
-    // does not work: zip.js sends a Range header to read a single unit out of
-    // the bundle, Range is not CORS-safelisted, so the browser preflights — and
-    // the Cloudflare Pages Function that serves /faction-models only answers
-    // GET/HEAD and sets no CORS headers (it is same-origin in prod, so it never
-    // needs them). The preflight fails and the 3D viewer sees "no models".
-    //
-    // Proxying here keeps the browser same-origin, exactly as in production, so
-    // no CORS is involved and production needs no dev-only concessions.
-    ...(DEV_LIVE && {
-      proxy: {
-        '/faction-models': {
-          target: PRODUCTION_ORIGIN,
-          changeOrigin: true,
-        },
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
       },
-    }),
-  },
+    },
+    server: {
+      // Bind to all addresses (required for Docker container access)
+      host: true,
+      fs: {
+        // Allow serving files from the factions folder at repo root
+        allow: ['..'],
+      },
+      // dev-live reads model bundles from production. Fetching them cross-origin
+      // does not work: zip.js sends a Range header to read a single unit out of
+      // the bundle, Range is not CORS-safelisted, so the browser preflights — and
+      // the Cloudflare Pages Function that serves /faction-models only answers
+      // GET/HEAD and sets no CORS headers (it is same-origin in prod, so it never
+      // needs them). The preflight fails and the 3D viewer sees "no models".
+      //
+      // Proxying here keeps the browser same-origin, exactly as in production, so
+      // no CORS is involved and production needs no dev-only concessions.
+      ...(devLive && {
+        proxy: {
+          '/faction-models': {
+            target: PRODUCTION_ORIGIN,
+            changeOrigin: true,
+          },
+        },
+      }),
+    },
+  }
 })


### PR DESCRIPTION
## Summary

Fixes unhandled promise rejections that occur when the browser tears down IndexedDB storage underneath open transactions (site data cleared, or the origin evicted under storage pressure). These surfaced in Sentry as stackless `AbortError: AbortError` errors (PA-PEDIA-2 / PA-PEDIA-3, both from a single page load).

Two review passes then found further defects, fixed in the follow-up commits below.

## Key Changes

**`5fc84c5` — the original fix**

- **New helper** (`web/src/services/idbTransaction.ts`): `claimTransactionDone()` marks a transaction's `done` promise as handled immediately after creation, so it isn't left rejected-and-unobserved when an earlier request fails and we exit before the final `await tx.done`.
- **Updated transaction callers**: `staticFactionCache.ts` (`cacheStaticFaction`, `deleteStaticFactionCache`, `clearStaticFactionCache`) and `localFactionStorage.ts` (`saveLocalFaction`, `deleteLocalFaction`).
- **Error filtering** (`web/src/lib/monitoring.ts`): `isIdbTeardownError()` drops the same leak coming from `idb`'s *read* shortcuts (`db.get`, `db.getAllKeys`), which only await `tx.done` for writes. That one is inside the library, so it can only be filtered.

**`d7665cb` — corrections to the above**

- The teardown filter was **unconditional**, but `beforeSend` sees handled events too. A force-close rejects `getLocalFactionIds()` with exactly `Connection is closing because of: …`, which `factionLoader.ts` reports deliberately via `reportError()` — so the filter was dropping the very report that made the noise safe to discard, leaving real storage failures invisible. Now gated on `mechanism.handled === false` via `isUnhandled()`.
- `clearModelCache()` in `modelLoader.ts` was missed in the original sweep — the one remaining readwrite transaction with the same leak shape.

**`eb5ca33` — two pre-existing defects on `main`** (separate commit so it can be split off)

- **Sentry initialised too late.** `App.tsx` calls `Sentry.wrapReactRouterRouting(Routes)` at module scope, and ESM evaluates imported modules before the importing module's body — so `initMonitoring()` in `main.tsx`'s body always ran after it. Verified against `@sentry/react` 10.68.0: wrapping before init returns `Routes` unchanged, after init it does not. Effect: no navigation transactions at all, and pageloads named by raw URL, so every unit page became its own transaction. Init moved to `instrument.ts`, imported first, with a test pinning the order since nothing else fails when it regresses.
- **Vite config read `.env` values from `process.env`**, which Vite never populates from `.env` files. The `web/.env.example` setup path silently did nothing — verified a token in `.env.local` yields no beacon in `dist/index.html` before this change and one after. `VITE_USE_LIVE_DATA` was worse, since app code reads it via `import.meta.env`, so the two halves disagreed. Now loads env files explicitly, with real shell vars still winning so CI is unaffected.

## Implementation Details

`idb` creates `tx.done` eagerly when wrapping `db.transaction()`, long before our code reaches `await tx.done`. If an earlier request rejects, we throw and never reach that final await, leaving an already-rejected `tx.done` with no handler. Attaching a no-op `.catch()` marks it handled without swallowing anything — `.catch()` returns a new promise and leaves `tx.done` itself untouched, so the real failure still propagates through the awaited request and callers that reach `await tx.done` still observe commit-time errors.

The trigger in the wild is Chromium force-closing the origin's storage (`Connection is closing because of: Force close delete origin`), which aborts every in-flight transaction. The reporting client looked automated (Chrome 117 in mid-2026, `timezone: UTC` with US geo), but the failure mode is reachable by real users, and the fix is about our error reporting staying trustworthy either way.

## Testing

959 tests pass (61 files), `tsc -b` and `eslint .` clean, production build succeeds, and `vite dev` smoke-tested after the config refactor. New tests: the six transaction regression tests fail with the exact `AbortError: AbortError` signature when the helper is disabled.

https://claude.ai/code/session_01HFswzvFdMRjkyHse1mYT1F