### PR TITLE
fix(scripts): update to archiver v8 class-based API

### DIFF
--- a/scripts/archiver.d.ts
+++ b/scripts/archiver.d.ts
@@ -1,0 +1,23 @@
+/**
+ * archiver 8.0.0 ships no type declarations of its own, and @types/archiver
+ * only describes the pre-8.0 factory-function API - so we declare the
+ * minimal surface this repo actually uses.
+ */
+declare module 'archiver' {
+  import { Transform } from 'node:stream'
+
+  interface ArchiverOptions {
+    zlib?: { level?: number }
+  }
+
+  class Archiver extends Transform {
+    constructor(options?: ArchiverOptions)
+    pointer(): number
+    directory(dirpath: string, destpath: string | false): this
+    finalize(): Promise<void>
+  }
+
+  export class ZipArchive extends Archiver {}
+  export class TarArchive extends Archiver {}
+  export class JsonArchive extends Archiver {}
+}

--- a/scripts/build-faction-zips.ts
+++ b/scripts/build-faction-zips.ts
@@ -9,7 +9,7 @@
 
 import * as fs from 'node:fs'
 import * as path from 'node:path'
-import archiver from 'archiver'
+import { ZipArchive } from 'archiver'
 
 interface FactionMetadata {
   identifier: string
@@ -96,7 +96,7 @@ async function createFactionZip(
 
   return new Promise((resolve, reject) => {
     const output = fs.createWriteStream(zipPath)
-    const archive = archiver('zip', {
+    const archive = new ZipArchive({
       zlib: { level: 9 }, // Maximum compression
     })
 

--- a/scripts/build-faction-zips.ts
+++ b/scripts/build-faction-zips.ts
@@ -106,7 +106,7 @@ async function createFactionZip(
       resolve(zipFilename)
     })
 
-    archive.on('error', (err) => {
+    archive.on('error', (err: Error) => {
       reject(err)
     })
 

--- a/scripts/build-model-bundles.ts
+++ b/scripts/build-model-bundles.ts
@@ -18,7 +18,7 @@
 
 import * as fs from 'node:fs'
 import * as path from 'node:path'
-import archiver from 'archiver'
+import { ZipArchive } from 'archiver'
 
 interface FactionMetadata {
   identifier: string
@@ -97,7 +97,7 @@ async function createModelZip(
 
   return new Promise((resolve, reject) => {
     const output = fs.createWriteStream(zipPath)
-    const archive = archiver('zip', { zlib: { level: 9 } })
+    const archive = new ZipArchive({ zlib: { level: 9 } })
 
     output.on('close', () => {
       const sizeMB = (archive.pointer() / 1024 / 1024).toFixed(2)

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -12,7 +12,6 @@
         "jszip": "^3.10.1"
       },
       "devDependencies": {
-        "@types/archiver": "^7.0.0",
         "@types/node": "^26.1.1",
         "tsx": "^4.23.1",
         "typescript": "^7.0.2"
@@ -460,16 +459,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@types/archiver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-7.0.0.tgz",
-      "integrity": "sha512-/3vwGwx9n+mCQdYZ2IKGGHEFL30I96UgBlk8EtRDDFQ9uxM1l4O5Ci6r00EMAkiDaTqD9DQ6nVrWRICnBPtzzg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/readdir-glob": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "26.1.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
@@ -478,16 +467,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
-      }
-    },
-    "node_modules/@types/readdir-glob": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
-      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@typescript/typescript-aix-ppc64": {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -19,7 +19,6 @@
     "jszip": "^3.10.1"
   },
   "devDependencies": {
-    "@types/archiver": "^7.0.0",
     "@types/node": "^26.1.1",
     "tsx": "^4.23.1",
     "typescript": "^7.0.2"


### PR DESCRIPTION
## Summary
- The Faction Data Release workflow failed on merge of #458: `import archiver from 'archiver'` throws `SyntaxError: The requested module 'archiver' does not provide an export named 'default'`
- Root cause: dependabot bumped `archiver` 7.0.1 → 8.0.0 in #451, which replaced the factory-function API (`archiver('zip', opts)`) with ESM classes (`ZipArchive`, `TarArchive`, `JsonArchive`) and dropped the default export
- This went unnoticed at merge time because Faction Data Release only triggers on `factions/**` pushes, and none happened between #451 and the next faction update (#458)
- Updates both call sites (`build-faction-zips.ts`, `build-model-bundles.ts`) to `import { ZipArchive } from 'archiver'` / `new ZipArchive(opts)`

## Test plan
- [x] `node --import tsx build-faction-zips.ts` succeeds locally, produces valid zips for all 6 factions
- [x] `node --import tsx build-model-bundles.ts` runs without the import error (no local model bundles to zip, but confirms the fix)
- [x] `node --import tsx --test manifest-ordering.test.ts model-bundles.test.ts` — all 15 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)