### PR TITLE
perf(manifest): read model unit counts from a sidecar, not the whole bundle

### DIFF
--- a/scripts/build-model-bundles.ts
+++ b/scripts/build-model-bundles.ts
@@ -19,6 +19,7 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { ZipArchive } from 'archiver'
+import { modelBundleSidecarName, type ModelBundleSidecar } from './model-bundles'
 
 interface FactionMetadata {
   identifier: string
@@ -112,6 +113,28 @@ async function createModelZip(
   })
 }
 
+/**
+ * Write the sidecar index next to a bundle: the facts the manifest generator
+ * needs (unit count) without downloading tens of MB. See `model-bundles.ts`.
+ */
+function createSidecar(
+  zipFilename: string,
+  metadata: FactionMetadata,
+  timestamp: string,
+  unitCount: number
+): string {
+  const sidecarName = modelBundleSidecarName(zipFilename)
+  const sidecar: ModelBundleSidecar = {
+    factionId: metadata.identifier,
+    version: metadata.version,
+    timestamp: parseInt(timestamp, 10),
+    unitCount,
+  }
+  fs.writeFileSync(path.join(OUTPUT_DIR, sidecarName), JSON.stringify(sidecar, null, 2))
+  console.log(`  Created ${sidecarName}`)
+  return sidecarName
+}
+
 async function main() {
   console.log('Building faction model bundles...')
   console.log(`Source: ${MODELS_DIR}`)
@@ -133,7 +156,13 @@ async function main() {
   console.log(`Build timestamp: ${timestamp}`)
   console.log()
 
-  const results: { factionId: string; filename: string; version: string; unitCount: number }[] = []
+  const results: {
+    factionId: string
+    filename: string
+    sidecar: string
+    version: string
+    unitCount: number
+  }[] = []
 
   for (const folderName of folders) {
     console.log(`Processing ${folderName}...`)
@@ -141,7 +170,14 @@ async function main() {
       const metadata = readFactionMetadata(folderName)
       const unitCount = readUnitCount(folderName)
       const filename = await createModelZip(folderName, metadata, timestamp)
-      results.push({ factionId: metadata.identifier, filename, version: metadata.version, unitCount })
+      const sidecar = createSidecar(filename, metadata, timestamp, unitCount)
+      results.push({
+        factionId: metadata.identifier,
+        filename,
+        sidecar,
+        version: metadata.version,
+        unitCount,
+      })
     } catch (error) {
       console.error(`  Error: ${error}`)
       process.exit(1)

--- a/scripts/generate-manifest.ts
+++ b/scripts/generate-manifest.ts
@@ -15,7 +15,12 @@ import * as path from 'node:path'
 import { execSync } from 'node:child_process'
 import JSZip from 'jszip'
 import { byTimestampDesc } from './manifest-ordering'
-import { indexModelBundles, selectModelBundle } from './model-bundles'
+import {
+  indexModelBundles,
+  selectModelBundle,
+  selectModelBundleSidecar,
+  type ModelBundleAsset,
+} from './model-bundles'
 
 const FACTIONS_DIR = path.join(import.meta.dirname, '..', 'factions')
 const OUTPUT_DIR = path.join(FACTIONS_DIR, 'dist')
@@ -179,16 +184,37 @@ function getModelReleaseAssets(): ReleaseAsset[] {
 }
 
 /**
- * Read unitCount from a model bundle's models.json.
+ * Read unitCount for a model bundle.
  *
- * NOTE (follow-up): this downloads the whole bundle (glb + textures, many MB)
- * just to read one integer. Fine at current scale, but for large backfills
- * consider a ranged read of the zip's models.json entry, or encoding the count
- * in the asset name / a small sidecar summary asset.
+ * Prefers the bundle's sidecar index asset (~100 bytes). Bundles published
+ * before sidecars existed have none, so we fall back to downloading the whole
+ * bundle (tens of MB) to read `models.json` — correct, just expensive, and it
+ * self-heals as those versions age out or get regenerated.
+ *
+ * This runs per version entry that has a bundle, on every manifest
+ * regeneration, i.e. on every faction-data push. Keep it cheap.
  */
-async function readModelUnitCount(downloadUrl: string): Promise<number> {
+async function readModelUnitCount(
+  bundle: ModelBundleAsset,
+  modelAssets: ModelBundleAsset[]
+): Promise<number> {
+  const sidecar = selectModelBundleSidecar(modelAssets, bundle.name)
+  if (sidecar) {
+    try {
+      const response = await fetch(sidecar.url)
+      if (response.ok) {
+        const parsed = (await response.json()) as { unitCount?: number }
+        if (typeof parsed.unitCount === 'number') return parsed.unitCount
+      }
+      console.warn(`  Sidecar unreadable for ${bundle.name}, falling back to bundle download`)
+    } catch (error) {
+      console.warn(`  Sidecar fetch failed for ${bundle.name} (${error}), falling back`)
+    }
+  }
+
   try {
-    const response = await fetch(downloadUrl)
+    console.log(`  Downloading ${bundle.name} to read its unit count (no sidecar)...`)
+    const response = await fetch(bundle.url)
     if (!response.ok) return 0
     const zip = await JSZip.loadAsync(await response.arrayBuffer())
     const indexFile = zip.file('models.json')
@@ -230,7 +256,8 @@ async function main() {
 
   // Fetch model bundles from the separate faction-models release (may be empty).
   console.log('Fetching model bundle assets...')
-  const modelBundleMap = indexModelBundles(getModelReleaseAssets())
+  const modelAssets = getModelReleaseAssets()
+  const modelBundleMap = indexModelBundles(modelAssets)
   console.log(`Found ${modelBundleMap.size} model bundle(s)`)
   console.log()
 
@@ -309,7 +336,7 @@ async function main() {
       // with no bundle of its own reports "no models"; older versions keep theirs.
       const bundle = selectModelBundle(modelBundleMap, factionId, zip.parsed!.version)
       if (bundle) {
-        const unitCount = await readModelUnitCount(bundle.asset.url)
+        const unitCount = await readModelUnitCount(bundle.asset, modelAssets)
         entry.models = {
           filename: bundle.asset.name,
           downloadUrl: `/${MODELS_RELEASE_TAG}/${bundle.asset.name}`,

--- a/scripts/model-bundles.test.ts
+++ b/scripts/model-bundles.test.ts
@@ -2,8 +2,10 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import {
   indexModelBundles,
+  modelBundleSidecarName,
   parseModelBundleName,
   selectModelBundle,
+  selectModelBundleSidecar,
   type ModelBundleAsset,
 } from './model-bundles'
 
@@ -84,4 +86,45 @@ test('returns null for a faction with no bundles at all', () => {
   const bundles = indexModelBundles([asset('exiles-0.7.4.6-pedia20260712230210-models.zip')])
   assert.equal(selectModelBundle(bundles, 'replicate', '0.5'), null)
   assert.equal(selectModelBundle(new Map(), 'exiles', '0.7.4.6'), null)
+})
+
+// --- sidecar index -------------------------------------------------------
+// The sidecar exists so manifest generation doesn't download tens of MB per
+// bundle to read one integer. See modelBundleSidecarName in model-bundles.ts.
+
+test('derives the sidecar name from a bundle name', () => {
+  assert.equal(
+    modelBundleSidecarName('exiles-0.7.4.6-pedia20260712230210-models.zip'),
+    'exiles-0.7.4.6-pedia20260712230210-models.index.json'
+  )
+})
+
+test('sidecars are not mistaken for bundles', () => {
+  const assets = [
+    asset('exiles-0.7.4.6-pedia20260712230210-models.zip'),
+    asset('exiles-0.7.4.6-pedia20260712230210-models.index.json'),
+  ]
+  // Only the zip is a bundle; indexing the sidecar too would double-count and
+  // could win the newest-stamp race with a non-downloadable asset.
+  assert.equal(indexModelBundles(assets).size, 1)
+  assert.equal(parseModelBundleName('exiles-0.7.4.6-pedia20260712230210-models.index.json'), null)
+})
+
+test('finds a bundle sidecar among release assets', () => {
+  const assets = [
+    asset('mla-124664-pedia20260712084632-models.zip'),
+    asset('exiles-0.7.4.6-pedia20260712230210-models.zip'),
+    asset('exiles-0.7.4.6-pedia20260712230210-models.index.json'),
+  ]
+  assert.equal(
+    selectModelBundleSidecar(assets, 'exiles-0.7.4.6-pedia20260712230210-models.zip')?.name,
+    'exiles-0.7.4.6-pedia20260712230210-models.index.json'
+  )
+})
+
+// Bundles published before sidecars existed have none. That must read as "fall
+// back to opening the bundle", never as "this bundle has no units".
+test('reports no sidecar for bundles predating them', () => {
+  const assets = [asset('mla-124632-pedia20260711230523-models.zip')]
+  assert.equal(selectModelBundleSidecar(assets, 'mla-124632-pedia20260711230523-models.zip'), null)
 })

--- a/scripts/model-bundles.ts
+++ b/scripts/model-bundles.ts
@@ -32,6 +32,17 @@ export interface ModelBundleAsset {
   url: string
 }
 
+/**
+ * Contents of a bundle's sidecar index asset — the few facts the manifest
+ * generator needs about a bundle without opening it.
+ */
+export interface ModelBundleSidecar {
+  factionId: string
+  version: string
+  timestamp: number
+  unitCount: number
+}
+
 /** A model bundle asset whose filename parsed successfully. */
 export interface ParsedModelBundle {
   factionId: string
@@ -89,4 +100,36 @@ export function selectModelBundle(
   version: string
 ): ParsedModelBundle | null {
   return byVersion.get(`${factionId.toLowerCase()}@${version}`) ?? null
+}
+
+/**
+ * Name of the sidecar index asset published next to a bundle.
+ *
+ * The sidecar exists so the manifest generator can read a bundle's `unitCount`
+ * with a ~100-byte fetch instead of downloading the whole bundle (tens of MB)
+ * to read one integer out of its `models.json`. That download runs for every
+ * version entry that has a bundle, on every manifest regeneration — i.e. on
+ * every faction-data push — so it grows with the bundle history.
+ *
+ * `-models.zip` -> `-models.index.json`, which cannot collide with a bundle
+ * name (the bundle pattern requires a `.zip` suffix, so sidecars are ignored by
+ * `indexModelBundles`).
+ */
+export function modelBundleSidecarName(bundleName: string): string {
+  return bundleName.replace(/\.zip$/, '.index.json')
+}
+
+/**
+ * Locate a bundle's sidecar among the release assets.
+ *
+ * Returns `null` for bundles published before sidecars existed; callers must
+ * fall back to reading `models.json` out of the bundle itself rather than
+ * treating a missing sidecar as "no units".
+ */
+export function selectModelBundleSidecar(
+  assets: ModelBundleAsset[],
+  bundleName: string
+): ModelBundleAsset | null {
+  const wanted = modelBundleSidecarName(bundleName)
+  return assets.find((a) => a.name === wanted) ?? null
 }

--- a/scripts/upload-model-bundles.ts
+++ b/scripts/upload-model-bundles.ts
@@ -23,7 +23,14 @@ const RELEASE_TAG = 'faction-models'
 
 interface ModelBuildSummary {
   timestamp: string
-  bundles: { factionId: string; filename: string; version: string; unitCount: number }[]
+  bundles: {
+    factionId: string
+    filename: string
+    /** Sidecar index name; absent in summaries written before sidecars existed. */
+    sidecar?: string
+    version: string
+    unitCount: number
+  }[]
 }
 
 function checkGhCli(): void {
@@ -67,16 +74,16 @@ function ensureReleaseExists(): void {
   )
 }
 
-function uploadZip(filename: string): void {
-  const zipPath = path.join(OUTPUT_DIR, filename)
-  if (!fs.existsSync(zipPath)) {
-    throw new Error(`Model bundle not found: ${zipPath}`)
+function uploadAsset(filename: string): void {
+  const assetPath = path.join(OUTPUT_DIR, filename)
+  if (!fs.existsSync(assetPath)) {
+    throw new Error(`Model bundle asset not found: ${assetPath}`)
   }
   console.log(`Uploading ${filename}...`)
   // Use raw execSync (not the error-swallowing exec wrapper): a failed upload
   // MUST fail the step, otherwise the manifest regen finds no bundle and the 3D
   // button silently never appears.
-  execSync(`gh release upload ${RELEASE_TAG} "${zipPath}" --clobber`, { stdio: 'inherit' })
+  execSync(`gh release upload ${RELEASE_TAG} "${assetPath}" --clobber`, { stdio: 'inherit' })
 }
 
 async function main() {
@@ -108,7 +115,14 @@ async function main() {
     // viewer in that window. `indexModelBundles` (model-bundles.ts) always
     // picks the newest stamp per faction+version, so keeping older rebuilds is
     // harmless — and preserves model history alongside the spec-zip history.
-    uploadZip(bundle.filename)
+    uploadAsset(bundle.filename)
+    // Sidecar AFTER the bundle: a sidecar with no bundle behind it would make
+    // the manifest generator report a unit count for something it cannot serve.
+    // The reverse (bundle, no sidecar) degrades safely — the generator falls
+    // back to reading models.json out of the bundle, as it did before sidecars.
+    if (bundle.sidecar) {
+      uploadAsset(bundle.sidecar)
+    }
     console.log()
   }
 


### PR DESCRIPTION
## Why

`generate-manifest` downloads an **entire model bundle** — up to 86 MB for MLA — to read one integer out of its `models.json`. It does this once per version entry that has a bundle, on **every manifest regeneration**, i.e. on every faction-data push:

```ts
// NOTE (follow-up): this downloads the whole bundle (glb + textures, many MB)
// just to read one integer.
async function readModelUnitCount(downloadUrl: string): Promise<number> {
```

That's ~190 MB of transfer per daily run today, and it grows with the bundle history — every new bundle adds another whole-file download to a workflow that runs whenever faction data changes.

This is the follow-up that note asked for. It also unblocks automatic model regeneration (#next PR), which is what makes bundles multiply in the first place.

## What

- `build-model-bundles` writes a ~100-byte sidecar next to each bundle: `{id}-{version}-pedia{ts}-models.index.json`, carrying `factionId`, `version`, `timestamp`, `unitCount`.
- `upload-model-bundles` publishes the sidecar **after** the bundle it describes.
- `generate-manifest` prefers the sidecar and falls back to the old whole-bundle read.

No change to `manifest.json`'s shape or contents, so nothing downstream moves — the web app can't tell the difference.

## Failure modes considered

- **Bundle with no sidecar** (everything published before this PR): falls back to downloading the bundle. A missing sidecar must read as "open the bundle", never as "this bundle has no units" — a wrong `0` would mean a version silently reporting no models.
- **Sidecar with no bundle**: can't happen — the sidecar uploads only after the bundle upload succeeds. That ordering is the reason it's a separate `uploadAsset` call rather than a batch.
- **Unreadable/corrupt sidecar**: warns and falls back rather than trusting it.
- **Sidecar mistaken for a bundle**: `indexModelBundles` requires a `.zip` suffix, so `.index.json` can't be indexed as a bundle and win the newest-stamp race with something undownloadable. Covered by a test.

## Verification

- `npx tsc --noEmit` clean; `npm test` 19/19 (4 new tests covering sidecar naming, lookup, the pre-sidecar fallback, and the not-a-bundle case).
- Ran `build:model-bundles` end to end against a real model folder: bundle + sidecar produced, summary carries the sidecar name.

```
Created mla-124667-pedia20260731123213-models.zip (0.12 MB)
Created mla-124667-pedia20260731123213-models.index.json
{ "factionId": "mla", "version": "124667", "timestamp": 20260731123213, "unitCount": 2 }
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01XweN4vsR5zW3M7zdnvFxdz)_