### PR TITLE
feat(ci): regenerate faction models automatically when faction data changes

### DIFF
--- a/.github/workflows/faction-models.yml
+++ b/.github/workflows/faction-models.yml
@@ -75,12 +75,18 @@ jobs:
 
       - name: Resolve profiles to regenerate
         id: resolve
+        # Dispatch inputs reach the script through env, never through `${{ }}`
+        # interpolation: expressions are pasted into the shell source before it
+        # runs, so an input containing shell metacharacters would execute.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_PROFILES: ${{ github.event.inputs.profiles }}
         run: |
           set -euo pipefail
           ALL="mla legion exiles bugs second-wave replicate"
 
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            INPUT="${{ github.event.inputs.profiles }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            INPUT="$INPUT_PROFILES"
             if [ -z "$INPUT" ]; then
               PROFILES="$ALL"
               echo "Manual dispatch, no filter — regenerating all profiles"
@@ -227,16 +233,23 @@ jobs:
 
       # --- Generate models --------------------------------------------------
       - name: Extract models
+        # Both values originate in dispatch inputs, so they arrive via env
+        # rather than `${{ }}` interpolation into the shell source. Word
+        # splitting `$PROFILES` into loop values is intended and safe: split
+        # words are data, not re-parsed shell.
+        env:
+          PROFILES: ${{ needs.plan.outputs.profiles }}
+          TEXTURE_SIZE: ${{ github.event.inputs.texture_size || '512' }}
         run: |
           set -euo pipefail
-          for profile in ${{ needs.plan.outputs.profiles }}; do
+          for profile in $PROFILES; do
             echo "==================== $profile ===================="
             /tmp/pa-pedia extract-models \
               --profile "$profile" \
               --pa-root /tmp/pa-media \
               --output ./models \
               --blender "$BLENDER_BIN" \
-              --texture-size "${{ github.event.inputs.texture_size || '512' }}"
+              --texture-size "$TEXTURE_SIZE"
           done
 
       - name: Build model bundles

--- a/.github/workflows/faction-models.yml
+++ b/.github/workflows/faction-models.yml
@@ -4,8 +4,16 @@ name: Faction Models
 # Blender and publishes them to the `faction-models` release, then regenerates
 # the manifest so the web app shows the "View 3D Model" button.
 #
-# Manual-dispatch only: a full run drives Blender over ~600 units and is heavy,
-# and models change rarely — so this is not on a daily cron (unlike faction data).
+# Runs automatically after `Faction Data Release`, regenerating ONLY the
+# factions whose data changed in the commit that release was built from. That
+# keeps the common case cheap: a single faction is ~1 minute of Blender on top
+# of ~1.5 minutes of fixed setup, against ~10 minutes for all six.
+#
+# Chained via `workflow_run` rather than a second `push` trigger on purpose:
+# both workflows finish by regenerating and uploading manifest.json, so running
+# them concurrently on the same push risks the data release overwriting the
+# manifest that records the bundle this run just published. Chaining makes this
+# run last, after the release completes.
 #
 # REQUIREMENTS:
 #   - The `pa-base-data` release archive must include unit .papa files. Re-run
@@ -14,6 +22,10 @@ name: Faction Models
 #   - PA_BASE_DATA_KEY secret (same as update-factions).
 
 on:
+  workflow_run:
+    workflows: ["Faction Data Release"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
     inputs:
       profiles:
@@ -37,11 +49,82 @@ env:
   BLENDER_VERSION: '5.1.2'
 
 jobs:
-  generate-models:
+  # Decide which profiles need regenerating before spinning up the heavy job.
+  # A push that touched no faction folder produces an empty list and the
+  # generate job is skipped entirely.
+  plan:
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    timeout-minutes: 5
+    # A failed data release may have published nothing, or half its zips.
+    # Regenerating models against that is pointless — wait for a good one.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    outputs:
+      profiles: ${{ steps.resolve.outputs.profiles }}
+      sha: ${{ steps.resolve.outputs.sha }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Build models from the exact commit the data release published, so a
+          # bundle's version always matches the faction metadata it was built
+          # from. `github.ref` (default branch tip) may already have moved on.
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
+          # Need the parent commit to diff against.
+          fetch-depth: 2
+
+      - name: Resolve profiles to regenerate
+        id: resolve
+        run: |
+          set -euo pipefail
+          ALL="mla legion exiles bugs second-wave replicate"
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            INPUT="${{ github.event.inputs.profiles }}"
+            if [ -z "$INPUT" ]; then
+              PROFILES="$ALL"
+              echo "Manual dispatch, no filter — regenerating all profiles"
+            else
+              PROFILES=$(echo "$INPUT" | tr ',' ' ')
+              echo "Manual dispatch — regenerating: $PROFILES"
+            fi
+          else
+            # Faction folders touched by the commit the release was built from.
+            # Diffing against the first parent handles both squash merges (what
+            # update-factions produces) and real merge commits.
+            CHANGED=$(git diff --name-only HEAD^ HEAD -- factions/ 2>/dev/null \
+              | cut -d/ -f2 | sort -u || true)
+            echo "Changed faction folders: ${CHANGED:-none}"
+
+            # Map folder -> profile id via metadata.json. The identifier IS the
+            # profile id (mla, second-wave, ...), so this never guesses at
+            # casing or dashes. factions/dist has no metadata.json and drops out.
+            PROFILES=""
+            for DIR in $CHANGED; do
+              META="factions/$DIR/metadata.json"
+              [ -f "$META" ] || continue
+              PROFILES="$PROFILES $(jq -r '.identifier' "$META")"
+            done
+            PROFILES=$(echo "$PROFILES" | xargs -n1 2>/dev/null | sort -u | xargs || true)
+          fi
+
+          if [ -z "$PROFILES" ]; then
+            echo "::notice::No faction data changed — skipping model generation"
+          else
+            echo "::notice::Regenerating models for: $PROFILES"
+          fi
+          echo "profiles=$PROFILES" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  generate-models:
+    needs: plan
+    if: needs.plan.outputs.profiles != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.plan.outputs.sha }}
 
       # --- PA base data (now includes unit .papa) ---------------------------
       - name: Download base data
@@ -109,38 +192,44 @@ jobs:
         run: npm ci
 
       # --- Headless Blender (pinned; addon validated on 5.1.x) --------------
+      # Download + extract is ~45s of the job's ~1.5 min fixed overhead, and the
+      # tarball never changes for a pinned version — so cache the extracted tree.
+      - name: Restore cached Blender
+        id: blender-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/blender
+          key: blender-${{ env.BLENDER_VERSION }}-linux-x64
+
       - name: Install Blender ${{ env.BLENDER_VERSION }}
         run: |
           set -euo pipefail
-          # Runtime libs Blender needs to start even in --background.
+          # Runtime libs Blender needs to start even in --background. Always
+          # installed: apt state is not part of the cached path.
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libgl1 libegl1 libxi6 libxrender1 libxxf86vm1 libxfixes3 libsm6 \
             libxkbcommon0 libxrandr2 libxinerama1 libxcursor1 xz-utils
-          MAJOR_MINOR=$(echo "${BLENDER_VERSION}" | cut -d. -f1,2)
-          URL="https://download.blender.org/release/Blender${MAJOR_MINOR}/blender-${BLENDER_VERSION}-linux-x64.tar.xz"
-          echo "Downloading $URL"
-          curl -fsSL "$URL" -o /tmp/blender.tar.xz
-          mkdir -p /tmp/blender
-          tar -xJf /tmp/blender.tar.xz -C /tmp/blender --strip-components=1
+          if [ -x /tmp/blender/blender ]; then
+            echo "Using cached Blender"
+          else
+            MAJOR_MINOR=$(echo "${BLENDER_VERSION}" | cut -d. -f1,2)
+            URL="https://download.blender.org/release/Blender${MAJOR_MINOR}/blender-${BLENDER_VERSION}-linux-x64.tar.xz"
+            echo "Downloading $URL"
+            curl -fsSL "$URL" -o /tmp/blender.tar.xz
+            mkdir -p /tmp/blender
+            tar -xJf /tmp/blender.tar.xz -C /tmp/blender --strip-components=1
+          fi
           echo "BLENDER_BIN=/tmp/blender/blender" >> "$GITHUB_ENV"
+          # Verifies the binary runs — a truncated or partial cache fails here
+          # rather than midway through conversion.
           /tmp/blender/blender --version
 
       # --- Generate models --------------------------------------------------
-      - name: Determine profiles
-        id: profiles
-        run: |
-          INPUT="${{ github.event.inputs.profiles }}"
-          if [ -z "$INPUT" ]; then
-            echo "profiles=mla legion exiles bugs second-wave replicate" >> "$GITHUB_OUTPUT"
-          else
-            echo "profiles=$(echo "$INPUT" | tr ',' ' ')" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Extract models
         run: |
           set -euo pipefail
-          for profile in ${{ steps.profiles.outputs.profiles }}; do
+          for profile in ${{ needs.plan.outputs.profiles }}; do
             echo "==================== $profile ===================="
             /tmp/pa-pedia extract-models \
               --profile "$profile" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -447,21 +447,28 @@ The base data is stored as an encrypted release asset on the `pa-base-data` tag.
 
 **GitHub Actions Workflow** (`.github/workflows/faction-models.yml`):
 
-Manual-dispatch only (`workflow_dispatch`) — a full run drives headless Blender over ~600 units and is heavy, and models change rarely (so it is not a daily cron).
+Runs **automatically** after `Faction Data Release` (via `workflow_run`), regenerating only the factions whose data changed in that commit. Also dispatchable manually (`workflow_dispatch`, optional profile filter; empty = all).
+
+**Why chained rather than a second `push` trigger**: both workflows finish by regenerating and uploading `manifest.json`. Running them concurrently on the same push risks the data release overwriting the manifest that records the bundle this run just published. Chaining makes model generation run last.
+
+**Cost** (measured): ~1 second per unit, plus ~1.5 minutes of fixed setup. A single faction is ~3 minutes; all six is ~12. Actions minutes are free and unmetered on this public repo, so the scoping is about wall-clock and release-asset churn, not billing.
 
 **How it works**:
-1. Downloads + decrypts the `pa-base-data` archive (must include unit `.papa` — see note above)
-2. Installs pinned headless Blender (`BLENDER_VERSION`, 5.1.x validated)
-3. Builds the CLI, runs `extract-models` per profile → `models/{Faction}/`
-4. `build-model-bundles` zips them → `models/dist/{id}-{version}-pedia{ts}-models.zip`
-5. Uploads bundles to the **`faction-models`** release (separate from `faction-data`)
-6. Regenerates the manifest so version entries gain their `models` field → the web app shows the "View 3D Model" button
+1. `plan` job resolves which profiles to regenerate — faction folders touched by the release commit, mapped to profile IDs via each folder's `metadata.json` `identifier`. No faction change ⇒ empty list ⇒ the heavy job is skipped.
+2. Downloads + decrypts the `pa-base-data` archive (must include unit `.papa` — see note above)
+3. Installs pinned headless Blender (`BLENDER_VERSION`, 5.1.x validated), restored from `actions/cache` when available
+4. Builds the CLI, runs `extract-models` per profile → `models/{Faction}/`
+5. `build-model-bundles` zips them → `models/dist/{id}-{version}-pedia{ts}-models.zip`, plus a small `-models.index.json` sidecar
+6. Uploads bundles + sidecars to the **`faction-models`** release (separate from `faction-data`)
+7. Regenerates the manifest so version entries gain their `models` field → the web app shows the "View 3D Model" button
 
 **Bundle ↔ version correlation** (`scripts/model-bundles.ts`):
 
-A version entry gets a `models` bundle only when one was built from **that exact version**. Model generation is manual while faction data refreshes daily, so expect drift: the moment a mod ships a new release, its newest entry has no bundle and the 3D button reports "no 3D model available" until someone dispatches the workflow. Exiles went 0.7.4.6 → 0.7.5 → 0.7.6 → 0.8 → 0.8.1 in the two weeks after its bundle was built, and shows no models on all of them.
+A version entry gets a `models` bundle only when one was built from **that exact version**, and the manifest never approximates — serving a neighbouring version's bundle would misrepresent what a unit currently looks like.
 
-Serving a neighbouring version's bundle instead was considered and rejected — a model shown against a version it wasn't built from misrepresents what the unit currently looks like. **Regenerating is the fix for a stale faction**; the manifest never approximates.
+Automatic regeneration is what makes that strictness affordable: every faction update rebuilds that faction's bundle, so a new version arrives with its own models within a few minutes rather than waiting for someone to dispatch the workflow. It also closes a subtler hole — upstream mods sometimes ship changed data *without* bumping their version (see `update-factions.yml`), and matching on version alone would have handed the new data an older bundle with no signal. Always rebuilding means a bundle can never be inherited by data it wasn't built from.
+
+Drift is now bounded by how quickly the workflow runs, not by how often someone remembers to. A version can still legitimately show no models: if its generation run failed, that version has no bundle until the next update or a manual dispatch.
 
 Older versions are unaffected: each entry is matched independently, so Exiles 0.7.4.6 keeps its bundle and its working viewer however far latest has moved on. This is also why `upload-model-bundles` never deletes old bundles.
 

--- a/scripts/model-bundles.ts
+++ b/scripts/model-bundles.ts
@@ -2,22 +2,24 @@
  * Correlating 3D model bundles with faction-data versions.
  *
  * A version entry gets a model bundle only when one was BUILT FROM THAT EXACT
- * VERSION. This is deliberate, and it is why a faction can currently show "no
- * 3D model" on its newest release:
+ * VERSION. Serving a neighbouring version's bundle instead was considered and
+ * rejected: a model shown against a version it was not built from is a quiet
+ * lie about what the unit currently looks like. Saying "no models yet" is
+ * honest, and the fix for a stale faction is to regenerate, not to approximate.
  *
- * Model bundles are produced by the `faction-models` workflow, which is
- * manual-dispatch only (a full run drives headless Blender over ~600 units).
- * Faction data is refreshed by a DAILY workflow that snapshots whatever
- * upstream has released. So the moment a mod ships a new version, its newest
- * entry has no bundle and the "View 3D Model" button correctly reports that
- * there are no models for it — until someone regenerates. Exiles went
- * 0.7.4.6 -> 0.7.5 -> 0.7.6 -> 0.8 -> 0.8.1 in the two weeks after its bundle
- * was built, which is exactly this.
+ * The `faction-models` workflow regenerates a faction automatically whenever
+ * its data changes (chained off `Faction Data Release`), which is what makes
+ * that strictness affordable — a new version arrives with its own bundle in
+ * minutes. It previously ran only on manual dispatch, so a mod that shipped a
+ * new release showed "no 3D model available" until someone remembered: Exiles
+ * went 0.7.4.6 -> 0.7.5 -> 0.7.6 -> 0.8 -> 0.8.1 in the two weeks after its
+ * bundle was built, with no models on any of them.
  *
- * Serving a neighbouring version's bundle instead was considered and rejected:
- * a model shown against a version it was not built from is a quiet lie about
- * what the unit currently looks like. Saying "no models yet" is honest, and the
- * fix for a stale faction is to regenerate, not to approximate.
+ * Exact-version matching also guards a case that automation alone does not:
+ * upstream mods sometimes ship changed data WITHOUT bumping their version. It
+ * is only safe to keep matching on version because every update rebuilds the
+ * bundle, so the newest bundle for a version was always built from the newest
+ * data for it.
  *
  * What this DOES guarantee is that older versions keep their own models: each
  * version entry is matched independently, so Exiles 0.7.4.6 keeps its bundle


### PR DESCRIPTION
## Why

`faction-models` was manual-dispatch only, so a faction that updated kept showing **"no 3D model available"** on its newest version until someone remembered to dispatch it. Exiles shipped 0.7.4.6 → 0.7.5 → 0.7.6 → 0.8 → 0.8.1 in two weeks with no models on any of them. Right now MLA 124667, Exiles 0.8.1 and Replicate 0.5 (which has never had a bundle) are all in that state.

The reason it was manual was cost. That turns out not to hold here:

- **Actions minutes are free** — `pa-pedia` is public, and the API reports `billable.UBUNTU.total_ms = 0` for the last models run.
- **It isn't that slow.** Measured from the three real runs: **~1 second per unit** (491 units in 9m31s; 109 units in 1m43s), plus ~1.5 min of fixed setup. A single faction is ~3 minutes; all six is ~12.

Since a faction update touches one faction, scoping the run to what changed makes the common case cheap.

## What

- **Trigger**: chained off `Faction Data Release` completing (`workflow_run`, `main`, success only).
- **New `plan` job**: diffs the release commit for touched `factions/*` folders and maps each to its profile ID via that folder's `metadata.json` `identifier` — so it never guesses at casing or dashes (`Second-Wave` → `second-wave`). No faction change ⇒ empty list ⇒ the heavy job is skipped entirely.
- **Blender caching**: `actions/cache` on the pinned extracted tree, removing ~45s of the ~1.5 min setup. Still runs `blender --version` afterwards so a truncated cache fails fast rather than midway through conversion.
- Manual dispatch is unchanged (optional profile filter, empty = all).

### Why `workflow_run` and not a second `push` trigger

Both workflows finish by regenerating and uploading `manifest.json`. Firing both on the same push makes them race, and the loser is the data release overwriting the manifest that records the bundle this run just published. Chaining makes model generation run last.

### Why no per-faction matrix

I'd originally planned one. With scoped triggering the common case is a *single* faction, and round-tripping ~120 MB of model output through artifacts between a matrix and a publish job would make that case slower. A 12-minute full regen is rare and free.

## Side effect: closes a hole in version matching

Bundles are correlated to faction data by `(factionId, version)` alone. But upstream mods regularly ship changed data **without** bumping their version — `update-factions.yml` handles this explicitly ("upstream changed without a version bump"), and Bugs v1.38, Legion v1.32.1 and Exiles v0.7.4.6 were each re-extracted twice. When that happened the new data silently inherited the old bundle. Always rebuilding on update means a bundle can never be inherited by data it wasn't built from.

## Verification

Profile resolution is the part most likely to be wrong, so I ran it against real history:

| Commit | Resolved |
|---|---|
| `chore: update Bugs to v1.38` | `bugs` |
| `chore: update Second Wave to v0.15.0` | `second-wave` |
| `feat(faction): add Replicate faction` | `replicate` |
| `chore(deps): Bump the npm-web-minor-patch group` | *(empty — job skipped)* |
| `chore: update MLA to v124664` | `mla` |

Diffing against the first parent, so it handles both the squash merges `update-factions` produces and real merge commits. YAML parses; `scripts` tsc + tests clean.

Docs updated (`CLAUDE.md`, and the doctrine comment in `scripts/model-bundles.ts` that described the manual model).

## After merge

Dispatching one full regen to backfill the three factions currently without bundles, then verifying on pa-bda.com.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XweN4vsR5zW3M7zdnvFxdz)_