### PR TITLE
fix(ci): deploy after model generation so new bundles become visible

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,9 +7,17 @@ on:
       - 'web/**'
       - 'schema/**'
       - 'functions/**'
-  # Also deploy when faction data is updated by the faction workflow
+  # Also deploy when faction data or model bundles are updated.
+  #
+  # BOTH are required because the build BAKES manifest.json into web/dist
+  # (see "Download faction data from release" below) — the site reads that
+  # static copy, not the release. Faction Models runs after Faction Data
+  # Release and republishes the manifest with the new `models` entries, which
+  # lands AFTER the data-release deploy has already baked the old one. Without
+  # a deploy on Faction Models too, a freshly generated bundle exists on the
+  # release but stays invisible until some unrelated push redeploys.
   workflow_run:
-    workflows: ["Faction Data Release"]
+    workflows: ["Faction Data Release", "Faction Models"]
     types: [completed]
     branches: [main]
   workflow_dispatch:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -460,7 +460,10 @@ Runs **automatically** after `Faction Data Release` (via `workflow_run`), regene
 4. Builds the CLI, runs `extract-models` per profile → `models/{Faction}/`
 5. `build-model-bundles` zips them → `models/dist/{id}-{version}-pedia{ts}-models.zip`, plus a small `-models.index.json` sidecar
 6. Uploads bundles + sidecars to the **`faction-models`** release (separate from `faction-data`)
-7. Regenerates the manifest so version entries gain their `models` field → the web app shows the "View 3D Model" button
+7. Regenerates the manifest so version entries gain their `models` field
+8. Completing triggers **Deploy to Cloudflare Pages**, which is what actually makes the button appear → see below
+
+**Why a deploy is required**: the deploy bakes `manifest.json` into `web/dist/factions/` and the site reads that static copy, *not* the release. Model generation finishes after the data-release deploy has already baked the older manifest, so `deploy.yml` lists **both** `Faction Data Release` and `Faction Models` in its `workflow_run` trigger. Drop the second one and bundles will exist on the release but stay invisible until an unrelated push redeploys.
 
 **Bundle ↔ version correlation** (`scripts/model-bundles.ts`):
 


### PR DESCRIPTION
## The bug

Automatic model regeneration (#466) publishes bundles and republishes `manifest.json` — but the site never sees it.

The deploy **bakes** the manifest into the build:

```yaml
- name: Download faction data from release
  run: gh release download faction-data --dir web/dist/factions --pattern "manifest.json"
```

The site reads that static copy, not the release. And `deploy.yml` chained only off `Faction Data Release`, so the real sequence is:

1. Faction data merges → **Faction Data Release** completes
2. **Deploy** fires and bakes the manifest *as it looks now* — before any model bundle exists
3. **Faction Models** finishes ~3 minutes later and republishes the manifest with the new `models` entries
4. Site keeps serving the copy baked at step 2 → **no models**, until some unrelated push happens to redeploy

## Observed live

After the full backfill regen, the release manifest listed models for all six factions while pa-pedia.com was still serving a copy baked 16 minutes earlier:

| Faction | Release manifest | Site was serving |
|---|---|---|
| exiles 0.8.1 | 109 units | **no models** |
| mla 124667 | 192 units | **no models** |
| replicate 0.5 | 11 units | **no models** |
| bugs 1.38 | `bugs-1.38-pedia20260731125725` | `bugs-1.38-pedia20260712084632` (stale bundle) |

## The fix

Add `Faction Models` to the deploy's `workflow_run` trigger, so the manifest carrying the new bundles gets baked and shipped.

A models run that resolves no profiles still completes and triggers a redundant deploy. That is cheap and idempotent, and `cancel-in-progress` on the `pages` concurrency group means the later deploy wins if the two overlap.

Also documented in `CLAUDE.md`, since this coupling is invisible from either workflow alone and easy to undo by accident.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XweN4vsR5zW3M7zdnvFxdz)_