### PR TITLE
Add a privacy notice at /privacy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,6 +278,26 @@ TypeScript types in `web/src/types/faction.ts` manually defined from schemas:
 - **Future Requirement**: If server-side faction sharing is implemented, add DOMPurify sanitization before storing/displaying shared content
 - **Best Practice**: Continue avoiding `dangerouslySetInnerHTML` for user-provided content
 
+### Privacy (no cookie banner by design)
+
+The site sets **no cookies** and needs no consent banner. That is a property worth
+preserving, not an accident:
+
+- **Client-side storage is consent-exempt** — `localStorage` holds only preferences the
+  visitor chose, and the IndexedDB stores are caches of data the visitor asked to see.
+  Nothing is a cross-site identifier.
+- **Cloudflare Web Analytics is cookieless** and Sentry Session Replay is deliberately off
+  (see `web/src/lib/monitoring.ts`). Enabling Replay would make the site consent-requiring.
+- **No third-party requests during browsing.** Anything that adds one — an embed, a
+  hotlinked asset, a CDN script — changes the "no banner" answer and should be raised
+  before merging.
+- **`web/src/pages/Privacy.tsx`** (`/privacy`, linked from `Footer.tsx`) is the Art. 13
+  notice. Its scope is deliberately narrow: what visitor data is processed and who
+  receives it, **not** how the site works. Individual storage keys and service
+  configuration stay out, so a new cache key needs no change here. The exception is
+  recipients — Art. 13(1)(e) requires them, so Cloudflare and Sentry are named and
+  `Privacy.test.tsx` asserts it. **Adding a processor means adding it to that page.**
+
 ### Monitoring (Sentry + Cloudflare Web Analytics)
 
 Both are free-tier and **inert unless configured** — no DSN means Sentry never initialises,

--- a/web/scripts/generate-sitemap.ts
+++ b/web/scripts/generate-sitemap.ts
@@ -54,6 +54,10 @@ function generateSitemap(): void {
   // Add "All Factions" page (route exists at /faction without ID)
   urls.push({ loc: '/faction', priority: '0.9', changefreq: 'weekly', lastmod: buildDate })
 
+  // Privacy policy — low priority, but it should be indexable so the notice is
+  // discoverable without having to land on the site first.
+  urls.push({ loc: '/privacy', priority: '0.3', changefreq: 'yearly', lastmod: buildDate })
+
   // Add each faction and its units
   for (const factionId of STATIC_FACTIONS) {
     // Faction page

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,12 +4,14 @@ import * as Sentry from '@sentry/react'
 import { FactionProvider } from '@/contexts/FactionContext'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
 import { Header } from '@/components/Header'
+import { Footer } from '@/components/Footer'
 import { ScrollToTop } from '@/components/ScrollToTop'
 import { FactionUpload } from '@/components/FactionUpload'
 import { CliDownload } from '@/components/CliDownload'
 import { Home } from '@/pages/Home'
 import { FactionDetail } from '@/pages/FactionDetail'
 import { UnitDetail } from '@/pages/UnitDetail'
+import { Privacy } from '@/pages/Privacy'
 
 // Gives Sentry the parameterised route (/faction/:id) rather than the raw URL,
 // so navigations group into one transaction per page instead of one per unit.
@@ -24,17 +26,23 @@ function App() {
       <ScrollToTop />
       <ErrorBoundary>
         <FactionProvider>
-          <div className="min-h-screen bg-background text-foreground">
+          <div className="min-h-screen flex flex-col bg-background text-foreground">
             <Header
               onUploadClick={() => setShowUpload(true)}
               onDownloadClick={() => setShowCliDownload(true)}
             />
-            <SentryRoutes>
-              <Route path="/" element={<Home />} />
-              <Route path="/faction" element={<FactionDetail />} />
-              <Route path="/faction/:id" element={<FactionDetail />} />
-              <Route path="/faction/:factionId/unit/:unitId" element={<UnitDetail />} />
-            </SentryRoutes>
+            {/* flex-1 keeps the footer at the bottom of the viewport on short
+                pages rather than floating mid-screen. */}
+            <main className="flex-1">
+              <SentryRoutes>
+                <Route path="/" element={<Home />} />
+                <Route path="/faction" element={<FactionDetail />} />
+                <Route path="/faction/:id" element={<FactionDetail />} />
+                <Route path="/faction/:factionId/unit/:unitId" element={<UnitDetail />} />
+                <Route path="/privacy" element={<Privacy />} />
+              </SentryRoutes>
+            </main>
+            <Footer />
 
             {/* Modals */}
             {showUpload && (

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -1,0 +1,35 @@
+import { Link } from 'react-router-dom'
+
+/**
+ * Site footer.
+ *
+ * Exists for the privacy link — GDPR Art. 13 expects the notice to be reachable
+ * from anywhere on the site, and the header is already full. Deliberately not a
+ * general nav: GitHub and the CLI download live in the header, and repeating
+ * them here would only dilute the one link this footer is for.
+ */
+export function Footer() {
+  return (
+    <footer className="mt-16 border-t border-border bg-card/40">
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex flex-col-reverse sm:flex-row items-center justify-between gap-5">
+          <p className="text-sm text-muted-foreground text-center sm:text-left">
+            Unofficial community project. Not affiliated with Planetary
+            Annihilation Inc.
+          </p>
+          {/* Full foreground contrast rather than the muted grey used for the
+              disclaimer: a privacy notice nobody can pick out of the page is
+              not meaningfully reachable. */}
+          <nav className="font-display text-sm tracking-wide">
+            <Link
+              to="/privacy"
+              className="px-3 py-2 rounded-lg text-foreground hover:bg-muted hover:text-primary transition-colors"
+            >
+              Privacy
+            </Link>
+          </nav>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/web/src/components/__tests__/Footer.test.tsx
+++ b/web/src/components/__tests__/Footer.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { screen } from '@testing-library/react'
+import { Footer } from '../Footer'
+import { renderWithProviders } from '@/tests/helpers'
+
+describe('Footer', () => {
+  it('links to the privacy policy from every page', () => {
+    renderWithProviders(<Footer />)
+    expect(screen.getByRole('link', { name: /privacy/i })).toHaveAttribute('href', '/privacy')
+  })
+
+  // The header already carries GitHub and the CLI download. Duplicating them
+  // here would compete with the one link this footer exists to surface.
+  it('stays a single-link footer', () => {
+    renderWithProviders(<Footer />)
+    expect(screen.getAllByRole('link')).toHaveLength(1)
+  })
+
+  it('carries the unaffiliated disclaimer', () => {
+    renderWithProviders(<Footer />)
+    expect(screen.getByText(/not affiliated with planetary annihilation inc/i)).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/Privacy.tsx
+++ b/web/src/pages/Privacy.tsx
@@ -1,0 +1,151 @@
+import { Link } from 'react-router-dom'
+import { SEO } from '@/components/SEO'
+import { CLI_RELEASE } from '@/config/releases'
+
+/**
+ * Privacy notice.
+ *
+ * Exists to satisfy GDPR Art. 13 transparency rather than to gather consent:
+ * the site sets no cookies, and everything it does store client-side is either
+ * a preference the visitor chose or a cache of the data they asked to see, so
+ * no consent banner is required. Keep it that way — anything that introduces a
+ * cross-site identifier (ad tags, Sentry Session Replay, a hotlinked
+ * third-party asset) changes that answer and needs this page revisited first.
+ *
+ * Scope is deliberately narrow: what visitor data is processed and who receives
+ * it. It is not documentation of how the site works, so individual storage keys
+ * and service configuration stay out. The one detail that cannot be dropped is
+ * the list of recipients — Art. 13(1)(e) requires them, hence Cloudflare and
+ * Sentry being named. Adding a new processor means adding it here.
+ */
+
+const LAST_UPDATED = '1 August 2026'
+
+interface SectionProps {
+  title: string
+  children: React.ReactNode
+}
+
+function Section({ title, children }: SectionProps) {
+  return (
+    <section className="mb-10">
+      <h2 className="text-xl sm:text-2xl font-display font-bold tracking-wide text-foreground mb-3">
+        {title}
+      </h2>
+      <div className="space-y-3 text-muted-foreground leading-relaxed">
+        {children}
+      </div>
+    </section>
+  )
+}
+
+export function Privacy() {
+  const githubUrl = `https://github.com/${CLI_RELEASE.githubRepo}`
+
+  return (
+    <>
+      <SEO
+        title="Privacy"
+        description="How PA-Pedia handles your data: no cookies, no accounts, no advertising, and no cross-site tracking."
+        canonicalPath="/privacy"
+      />
+
+      <div className="container mx-auto px-4 py-8">
+        <div className="max-w-3xl mx-auto">
+          <nav className="mb-6 text-sm">
+            <Link
+              to="/"
+              className="text-muted-foreground hover:text-foreground transition-colors"
+            >
+              &larr; Back to factions
+            </Link>
+          </nav>
+
+          <h1 className="text-3xl sm:text-4xl font-display font-bold tracking-wider text-foreground mb-2">
+            PRIVACY
+          </h1>
+          <p className="text-sm text-muted-foreground mb-10">
+            Last updated {LAST_UPDATED}
+          </p>
+
+          <div className="border border-border rounded-lg p-5 mb-10 bg-card">
+            <p className="text-foreground leading-relaxed">
+              PA-Pedia is a free, open-source reference site for Planetary
+              Annihilation: Titans. It does not use cookies, does not require an
+              account, and carries no advertising or cross-site tracking.
+            </p>
+          </div>
+
+          <Section title="Data stored on your device">
+            <p>
+              The site uses your browser&apos;s local storage to hold your display
+              preferences and to cache the faction data you have viewed. This
+              stays on your device, is not transmitted to us, and is not used to
+              identify you. You may remove it at any time by clearing site data
+              for pa-pedia.com in your browser settings.
+            </p>
+          </Section>
+
+          <Section title="Analytics">
+            <p>
+              We collect aggregate visitor statistics using a cookieless
+              analytics service. It sets no cookies, stores nothing on your
+              device, and does not profile you or track you across other sites.
+            </p>
+          </Section>
+
+          <Section title="Error reporting">
+            <p>
+              When an error occurs, a diagnostic report is sent to our
+              error-monitoring provider so that the fault can be corrected. IP
+              addresses are not retained, and session recording is disabled.
+            </p>
+          </Section>
+
+          <Section title="Who receives your data">
+            <p>
+              The site is hosted by Cloudflare, which also provides our
+              analytics. As with any web host, Cloudflare necessarily processes
+              your IP address in order to deliver pages and to protect the site
+              against abuse. Error reports are processed by Sentry.
+            </p>
+            <p>
+              No other third-party content is loaded while you browse, and your
+              data is not sold or shared with anyone else.
+            </p>
+          </Section>
+
+          <Section title="Your rights">
+            <p>
+              We hold no account, profile or contact record relating to you, so
+              there is no personal data for us to provide, export or erase on
+              request. If you are in the UK or EU, you have the right to lodge a
+              complaint with your data protection authority.
+            </p>
+            <p>
+              If you have a question about this notice, or believe any part of it
+              to be inaccurate, please open an issue on{' '}
+              <a
+                href={githubUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                the project&apos;s GitHub repository
+              </a>
+              .
+            </p>
+          </Section>
+
+          <Section title="Changes to this notice">
+            <p>
+              We may change how the site operates, and this notice along with it,
+              at any time and without prior notification. The date above indicates
+              when it was last revised.
+            </p>
+          </Section>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/web/src/pages/__tests__/Privacy.test.tsx
+++ b/web/src/pages/__tests__/Privacy.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { screen } from '@testing-library/react'
+import { Privacy } from '../Privacy'
+import { renderWithProviders } from '@/tests/helpers'
+
+describe('Privacy', () => {
+  it('renders the page heading', () => {
+    renderWithProviders(<Privacy />)
+    expect(screen.getByRole('heading', { level: 1, name: /privacy/i })).toBeInTheDocument()
+  })
+
+  it('states the core position: no cookies, accounts, ads or tracking', () => {
+    renderWithProviders(<Privacy />)
+    const summary = screen.getByText(/does not use cookies/i)
+    expect(summary).toBeInTheDocument()
+    expect(summary.textContent).toMatch(/does not require an account/i)
+    expect(summary.textContent).toMatch(/no advertising or cross-site tracking/i)
+  })
+
+  /**
+   * Art. 13(1)(e) requires the recipients of personal data to be disclosed, so
+   * naming the processors is the one piece of detail this notice cannot trade
+   * away for brevity. A new processor added without appearing here is an
+   * undisclosed recipient.
+   */
+  it('names every processor that receives visitor data', () => {
+    renderWithProviders(<Privacy />)
+    const recipients = screen.getByText(/hosted by Cloudflare/i)
+    expect(recipients.textContent).toMatch(/Sentry/)
+  })
+
+  it('records that analytics is cookieless', () => {
+    renderWithProviders(<Privacy />)
+    expect(screen.getByText(/cookieless/i)).toBeInTheDocument()
+  })
+
+  it('tells visitors how to erase what is held on their device', () => {
+    renderWithProviders(<Privacy />)
+    expect(screen.getByText(/clearing site data/i)).toBeInTheDocument()
+  })
+
+  it('sets out the right to complain to a supervisory authority', () => {
+    renderWithProviders(<Privacy />)
+    expect(screen.getByText(/data protection authority/i)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## What

Adds `/privacy`, linked from a new site footer.

## Why

The site had no privacy notice. It sets no cookies and needs **no consent banner** — the `localStorage` preferences are settings the visitor chose, the IndexedDB stores are caches of data they asked to see, Cloudflare Web Analytics is cookieless, and Sentry Session Replay is deliberately off. None of that is a cross-site identifier.

But GDPR Art. 13 still expects visitors to be told what is processed and by whom, and that part was missing:

- **Cloudflare** receives every visitor's IP as the site host, and also provides the analytics
- **Sentry** receives error reports

## Scope

The notice is deliberately narrow: **what happens to visitor data and who receives it, not how the site works.** Earlier drafts enumerated every `localStorage` and IndexedDB key and explained each service's configuration — that is implementation documentation, and it told a reader nothing about their own privacy. Individual storage keys stay out, so adding a future cache key needs no change to the page.

The one detail that can't be traded for brevity is the recipients, since Art. 13(1)(e) requires them. Cloudflare and Sentry are named, and `Privacy.test.tsx` asserts both appear — so **a new processor cannot be added without the test failing.**

Also included: the right to lodge a complaint with a supervisory authority, which was missing. No promise is made about notifying anyone in advance of changes.

## Footer

GitHub and the CLI download already live in the header, so the footer carries a single link, and its test asserts that to keep it from accreting nav. The app shell becomes a flex column with the routes wrapped in `<main>`, so the footer sits at the bottom of the viewport on short pages rather than floating mid-screen. `/privacy` is added to the sitemap at low priority so the notice is discoverable without landing on the site first.

## Testing

- `npm run build` — clean
- `npm run lint` — clean
- `npm run test:run` — 968 passed (9 new)
- `npx playwright test` — 85 passed, confirming the `<main>` wrapper doesn't disturb existing layout

---
_Generated by [Claude Code](https://claude.ai/code/session_013pVTbe1vmfgevhosRGkAfM)_