### PR TITLE
fix(web): survive browser page translation on the 3D model button

### DIFF
--- a/web/src/components/UnitModelSection.tsx
+++ b/web/src/components/UnitModelSection.tsx
@@ -129,11 +129,16 @@ export function UnitModelSection({
     }
   }, [factionId, unitId, version])
 
+  // Labels are wrapped, not left as bare text beside the icon: Chrome/Edge page
+  // translation moves bare text nodes into <font> wrappers, and this button
+  // swaps its first child (spinner → icon) once the lookup resolves, so React
+  // would insert against a text node that is no longer its child. An element's
+  // only text child is set via textContent, so it survives translation.
   if (availability === 'checking') {
     return (
       <button type="button" data-testid="view-3d-model-checking" disabled className={INERT_BUTTON}>
         <Spinner />
-        Checking…
+        <span>Checking…</span>
       </button>
     )
   }
@@ -154,7 +159,7 @@ export function UnitModelSection({
         className={INERT_BUTTON}
       >
         <span aria-hidden="true">🧊</span>
-        View 3D Model
+        <span>View 3D Model</span>
       </button>
     )
   }
@@ -168,7 +173,7 @@ export function UnitModelSection({
         className={`${BUTTON_BASE} border-gray-300 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700`}
       >
         <span aria-hidden="true">🧊</span>
-        View 3D Model
+        <span>View 3D Model</span>
       </button>
 
       {open && (

--- a/web/src/components/__tests__/UnitModelSection.test.tsx
+++ b/web/src/components/__tests__/UnitModelSection.test.tsx
@@ -1,3 +1,4 @@
+import { Component, type ReactNode } from 'react'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -180,5 +181,103 @@ describe('UnitModelSection — checking state', () => {
 
     expect(await screen.findByTestId('view-3d-model')).toBeEnabled()
     await waitFor(() => expect(screen.queryByTestId('view-3d-model-checking')).toBeNull())
+  })
+})
+
+describe('UnitModelSection — survives browser page translation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  /** Wrap each text node in a <font>, as Chrome/Edge translation does. */
+  function simulateBrowserTranslation(root: HTMLElement) {
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+    const texts: Text[] = []
+    while (walker.nextNode()) texts.push(walker.currentNode as Text)
+
+    for (const text of texts) {
+      if (!text.data.trim()) continue
+      const font = document.createElement('font')
+      text.replaceWith(font)
+      font.appendChild(text)
+    }
+    // Without a detached text node these tests would pass for the wrong reason.
+    expect(root.querySelectorAll('font').length).toBeGreaterThan(0)
+  }
+
+  class CaptureBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
+    state: { error: Error | null } = { error: null }
+    static getDerivedStateFromError(error: Error) {
+      return { error }
+    }
+    render() {
+      if (this.state.error) {
+        return <div data-testid="boundary-tripped">{this.state.error.message}</div>
+      }
+      return this.props.children
+    }
+  }
+
+  it('swaps the spinner for the trigger after the page has been translated', async () => {
+    mockGetIndex.mockResolvedValue(indexWith('radar'))
+    const { container } = render(
+      <CaptureBoundary>
+        <UnitModelSection factionId="MLA" unitId="radar" />
+      </CaptureBoundary>
+    )
+
+    // Translation runs while the availability lookup is still in flight; the
+    // lookup resolving is what swaps the spinner for the icon.
+    expect(screen.getByTestId('view-3d-model-checking')).toBeInTheDocument()
+    simulateBrowserTranslation(container)
+
+    const button = await screen.findByTestId('view-3d-model')
+    expect(screen.queryByTestId('boundary-tripped')).toBeNull()
+    expect(button).toHaveTextContent('View 3D Model')
+  })
+
+  it('reaches the unavailable state after the page has been translated', async () => {
+    mockGetIndex.mockResolvedValue(null)
+    const { container } = render(
+      <CaptureBoundary>
+        <UnitModelSection factionId="MLA" unitId="radar" />
+      </CaptureBoundary>
+    )
+
+    simulateBrowserTranslation(container)
+
+    const button = await screen.findByTestId('view-3d-model')
+    expect(screen.queryByTestId('boundary-tripped')).toBeNull()
+    expect(button).toHaveAttribute('data-state', 'none')
+  })
+
+  it('reaches the error state after the page has been translated', async () => {
+    mockGetIndex.mockRejectedValue(new Error('network'))
+    const { container } = render(
+      <CaptureBoundary>
+        <UnitModelSection factionId="MLA" unitId="radar" />
+      </CaptureBoundary>
+    )
+
+    simulateBrowserTranslation(container)
+
+    const button = await screen.findByTestId('view-3d-model')
+    expect(screen.queryByTestId('boundary-tripped')).toBeNull()
+    expect(button).toHaveAttribute('data-state', 'error')
+  })
+
+  it('still opens the modal once translated', async () => {
+    mockGetIndex.mockResolvedValue(indexWith('radar'))
+    const { container } = render(
+      <CaptureBoundary>
+        <UnitModelSection factionId="MLA" unitId="radar" />
+      </CaptureBoundary>
+    )
+
+    simulateBrowserTranslation(container)
+
+    await userEvent.click(await screen.findByTestId('view-3d-model'))
+    expect(screen.queryByTestId('boundary-tripped')).toBeNull()
+    expect(screen.getByTestId('model-modal')).toHaveTextContent('modal:radar')
   })
 })


### PR DESCRIPTION
Fixes [PA-PEDIA-4](https://jamie-mulcahy.sentry.io/issues/PA-PEDIA-4). Replaces #474, which guarded an unrelated component.

## What's actually happening

Chrome and Edge page translation rewrites the DOM underneath React. Each bare text node is replaced by a `<font>` element wrapping that same text node — the text survives, but its parent is now the `<font>`, not the element React rendered it into. Any text node React is still tracking is therefore no longer a child of the element React will later insert into, and the next structural update throws `NotFoundError` out of `insertBefore`.

`UnitModelSection` was the app's one genuinely exposed spot, because it combines both preconditions:

1. Its button held an element and a **bare text label** side by side (`<Spinner />` + `Checking…`), so React tracked that label as its own text node.
2. Its children **change type** moments after mount — the spinner becomes the 🧊 icon when the availability lookup resolves, which is exactly when a translation pass has just finished.

So React removed the spinner and called `button.insertBefore(icon, label)` against a text node the browser had already moved into a `<font>`. `ErrorBoundary` caught it and replaced the whole unit page with the error fallback.

The component stack on the Sentry event maps onto this exactly:

```
span → button → UnitModelSection → div → div → div → div → CurrentFactionProvider → UnitDetail
```

That is `<span aria-hidden="true">🧊</span>` inside the button, then the four nested divs at `UnitDetail.tsx:1417/1416/1414/476`. The `span` frame is the node being placed — the icon that replaces the spinner.

## Why it's translation and not a race

All nine events come from non-English locales — CN ×4, TW, SG ×2, BR — on Chrome or Edge, i.e. precisely the population that gets "Translate this page" offered on an English-language site. Not one event from an English-speaking region. They span every faction and unit (`mla/tank_heavy_armor`, `legion/l_hover_tank_adv`, `exiles/t_battleship`, `exiles/cruiser`, …), so nothing about the crash is model-data-specific, and the single sampled event carried `locale: "zh-CN"`.

## The fix

Wrap each label in its own `<span>`.

A label that is the **only** child of an element is immune, because React sets it via `textContent` on that element rather than tracking a separate text node — translation has nothing to detach. And the button's own children become two elements, which translation leaves in place, so the `insertBefore` reference stays valid.

Rendering is unchanged: the buttons are `inline-flex`, where the bare text was already an anonymous flex item, so `gap-2` produces the same layout.

## Tests

Four regression tests simulate a real translation pass over the rendered button — walking the subtree and wrapping each non-blank text node in a `<font>` in place — then let the availability lookup resolve and assert the transition doesn't trip an error boundary. They cover the available, unavailable, and error states plus opening the modal.

All four fail against the unpatched component with jsdom's wording of the same DOMException (`NotFoundError: The child can not be found in the parent.`) and pass with the fix. Full suite: 972 passing, lint and typecheck clean.

## Note on #474

The Seer patch added a `cancelled` guard to `UnitModelViewer` — a different component, only mounted after the user clicks into the modal, and not present in the reported component stack. The guard it added is also unreachable: there is no `await` between it and the pre-existing `cancelled` check above it. It would not have changed this error.

## Not changed

`FactionUpload.tsx:215` and `:280` have the same element-plus-bare-text shape in a button, but their children never change structurally, so React never inserts a sibling next to the text and they cannot hit this. Left alone to keep the fix reviewable — worth tidying if those buttons ever gain conditional content.

---
_Generated by [Claude Code](https://claude.ai/code/session_016XGFEfTTvnQ1LoKBjW5tS2)_